### PR TITLE
Move buttonmap.xml location to resources/ subdirectory

### DIFF
--- a/src/input/ButtonMapper.cpp
+++ b/src/input/ButtonMapper.cpp
@@ -28,7 +28,7 @@
 #include "kodi/libXBMC_addon.h"
 #include "tinyxml.h"
 
-#define BUTTONMAP_XML          "buttonmap.xml"
+#define BUTTONMAP_XML          "resources/buttonmap.xml"
 #define DEFAULT_CONTROLLER_ID  "game.controller.default"
 using namespace LIBRETRO;
 


### PR DESCRIPTION
Ref: https://trello.com/c/b8wQGi46/28-move-buttonmap-xml-for-emulator-addons-into-resource-directory

Requires corresponding adjustment to existing libretro add-ons.