### PR TITLE
LoadStandalone must call retro_load_game with NULL

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -329,8 +329,7 @@ GAME_ERROR LoadStandalone(void)
   if (!CLIENT)
     return GAME_ERROR_FAILED;
 
-  retro_game_info empty = { "", NULL, 0, NULL };
-  if (!CLIENT->retro_load_game(&empty))
+  if (!CLIENT->retro_load_game(NULL))
     return GAME_ERROR_FAILED;
 
   return GAME_ERROR_NO_ERROR;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -332,6 +332,13 @@ GAME_ERROR LoadStandalone(void)
   if (!CLIENT->retro_load_game(NULL))
     return GAME_ERROR_FAILED;
 
+  CInputManager::Get().OpenPort(0);
+
+  // TODO
+  CInputManager::Get().OpenPort(1);
+  CInputManager::Get().OpenPort(2);
+  CInputManager::Get().OpenPort(3);
+
   return GAME_ERROR_NO_ERROR;
 }
 


### PR DESCRIPTION
The [libretro API](Ref: https://github.com/libretro/RetroArch/blob/master/libretro-common/include/libretro.h#L605) documentation states that `retro_load_game` must be called with `NULL` as arguments for standalone games.

This fixes a crash in the scummvm core which supports both direct game
launching and standalone mode. The crash was introduced by the change:
https://github.com/libretro/scummvm/commit/4c1c4ff354e782734e34a0e7e556d8640046a8de.