### PR TITLE
Generate settings files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,11 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/log/Log.cpp
                      src/log/LogAddon.cpp
                      src/log/LogConsole.cpp
+                     src/settings/LanguageGenerator.cpp
                      src/settings/LibretroSetting.cpp
                      src/settings/LibretroSettings.cpp
                      src/settings/Settings.cpp
+                     src/settings/SettingsGenerator.cpp
                      src/utils/PathUtils.cpp
                      src/video/VideoStream.cpp)
 

--- a/src/settings/LanguageGenerator.cpp
+++ b/src/settings/LanguageGenerator.cpp
@@ -1,0 +1,83 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "LanguageGenerator.h"
+
+#include <fstream>
+
+using namespace LIBRETRO;
+
+CLanguageGenerator::CLanguageGenerator(const std::string& addonId, const std::string& generatedDir) :
+  m_strAddonId(addonId)
+{
+  m_strFilePath = generatedDir + "/" SETTINGS_GENERATED_LANGUAGE_NAME;
+}
+
+bool CLanguageGenerator::GenerateLanguage(const LibretroSettings& settings)
+{
+  if (m_strAddonId.empty())
+    return false;
+
+  std::ofstream file(m_strFilePath, std::ios::trunc);
+  if (!file.is_open())
+    return false;
+
+  file << "# " << m_strAddonId << " language file" << std::endl;
+  file << "# Addon Name: " << m_strAddonId << std::endl;
+  file << "# Addon id: " << m_strAddonId << std::endl;
+  file << "# Addon Provider: libretro" << std::endl;
+  file << "msgid \"\"" << std::endl;
+  file << "msgstr \"\"" << std::endl;
+  file << "\"Project-Id-Version: " << m_strAddonId << "\\n\"" << std::endl;
+  file << "\"Report-Msgid-Bugs-To: alanwww1@xbmc.org\\n\"" << std::endl;
+  file << "\"POT-Creation-Date: 2016-10-25 17:00+8\\n\"" << std::endl;
+  file << "\"PO-Revision-Date: 2016-10-25 17:00+8\\n\"" << std::endl;
+  file << "\"Last-Translator: Kodi Translation Team\\n\"" << std::endl;
+  file << "\"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\\n\"" << std::endl;
+  file << "\"MIME-Version: 1.0\\n\"" << std::endl;
+  file << "\"Content-Type: text/plain; charset=UTF-8\\n\"" << std::endl;
+  file << "\"Content-Transfer-Encoding: 8bit\\n\"" << std::endl;
+  file << "\"Language: en\\n\"" << std::endl;
+  file << "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"" << std::endl;
+  file << std::endl;
+
+  unsigned int settingId = SETTING_ID_START;
+
+  // Category name
+  file << "msgctxt \"#" << settingId++ << "\"" << std::endl;
+  file << "msgid \"Settings\"" << std::endl;
+  file << "msgstr \"\"" << std::endl;
+  file << std::endl;
+
+  for (const auto& setting : settings)
+  {
+    // TODO: xml-encode description
+    const std::string& description = setting.second.Description();
+
+    file << "msgctxt \"#" << settingId++ << "\"" << std::endl;
+    file << "msgid \"" << description << "\"" << std::endl;
+    file << "msgstr \"\"" << std::endl;
+    file << std::endl;
+  }
+
+  file.close();
+
+  return true;
+}

--- a/src/settings/LanguageGenerator.h
+++ b/src/settings/LanguageGenerator.h
@@ -19,23 +19,21 @@
  */
 #pragma once
 
+#include "SettingsTypes.h"
+
 #include <string>
 
 namespace LIBRETRO
 {
-  class PathUtils
+  class CLanguageGenerator
   {
   public:
-    /*!
-     * \brief Remove the slash at the end of a path
-     *
-     * NOTE: Trailing slash causes some libretro cores to fail
-     */
-    static void RemoveSlashAtEnd(std::string& path);
+    CLanguageGenerator(const std::string& addonId, const std::string& generatedDir);
 
-    /*!
-     * \brief Get the base filename, or empty if path ends in a / or \
-     */
-    static std::string GetBasename(const std::string& path);
+    bool GenerateLanguage(const LibretroSettings& settings);
+
+  private:
+    std::string m_strAddonId;
+    std::string m_strFilePath;
   };
 }

--- a/src/settings/LibretroSetting.cpp
+++ b/src/settings/LibretroSetting.cpp
@@ -56,9 +56,17 @@ void CLibretroSetting::Parse(const std::string& libretroValue)
       size_t pos;
       if ((pos = retroVal.find(';')) != std::string::npos)
       {
+        // Set description
+        description = retroVal.substr(0, pos);
+
+        // Advance past semicolon
         pos++;
+
+        // Advance past spaces
         while (pos < retroVal.size() && retroVal[pos] == ' ')
           pos++;
+
+        // Set values
         values = retroVal.substr(pos);
       }
       else

--- a/src/settings/LibretroSetting.cpp
+++ b/src/settings/LibretroSetting.cpp
@@ -107,4 +107,5 @@ void CLibretroSetting::Parse(const std::string& libretroValue)
 
   m_description = std::move(strDescription);
   m_values = std::move(vecValues);
+  m_valuesStr = std::move(strValues);
 }

--- a/src/settings/LibretroSetting.h
+++ b/src/settings/LibretroSetting.h
@@ -34,6 +34,7 @@ namespace LIBRETRO
     const std::string&              Key() const          { return m_key; }
     const std::string&              Description() const  { return m_description; }
     const std::vector<std::string>& Values() const       { return m_values; }
+    const std::string&              ValuesStr() const    { return m_valuesStr; } // Original pipe-deliminated values string
     const std::string&              CurrentValue() const { return m_currentValue; }
 
     // The libretro API defaults the setting to its first value
@@ -47,6 +48,7 @@ namespace LIBRETRO
     std::string              m_key;
     std::string              m_description;
     std::vector<std::string> m_values;
+    std::string              m_valuesStr;
     std::string              m_currentValue;
   };
 } // namespace LIBRETRO

--- a/src/settings/LibretroSettings.h
+++ b/src/settings/LibretroSettings.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "LibretroSetting.h"
+#include "SettingsTypes.h"
 
 #include "p8-platform/threads/mutex.h"
 
@@ -51,13 +51,19 @@ namespace LIBRETRO
     void SetCurrentValue(const std::string& name, const std::string& value);
 
   private:
+    /*!
+     * \brief Generate settings and language files for Kodi
+     */
+    void GenerateSettings();
+
     // Frontend variables
     ADDON::CHelper_libXBMC_addon* m_addon;
     std::string                   m_profileDirectory;
 
     // Settings variables
-    std::map<std::string, CLibretroSetting> m_settings;
-    bool                                    m_bChanged;
-    P8PLATFORM::CMutex                      m_mutex;
+    LibretroSettings   m_settings;
+    bool               m_bChanged;
+    bool               m_bGenerated; // True if settings and language files have been generated
+    P8PLATFORM::CMutex m_mutex;
   };
 } // namespace LIBRETRO

--- a/src/settings/SettingsGenerator.cpp
+++ b/src/settings/SettingsGenerator.cpp
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SettingsGenerator.h"
+
+#include <fstream>
+
+using namespace LIBRETRO;
+
+CSettingsGenerator::CSettingsGenerator(const std::string& generatedDir)
+{
+  m_strFilePath = generatedDir + "/" SETTINGS_GENERATED_SETTINGS_NAME;
+}
+
+bool CSettingsGenerator::GenerateSettings(const LibretroSettings& settings)
+{
+  std::ofstream file(m_strFilePath, std::ios::trunc);
+  if (!file.is_open())
+    return false;
+
+  unsigned int settingId = SETTING_ID_START;
+
+  file << "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" << std::endl;
+  file << "<settings>" << std::endl;
+  file << "\t<category label=\"" << settingId++ << "\">" << std::endl;
+
+  for (const auto& setting : settings)
+  {
+    const std::string& key = setting.first;
+    const std::string& strValues = setting.second.ValuesStr();
+    const std::string& defaultValue = setting.second.DefaultValue();
+
+    file << "\t\t<setting label=\"" << settingId++ << "\" type=\"select\" id=\"" << key << "\" values=\"" << strValues << "\" default=\"" << defaultValue << "\"/>" << std::endl;
+  }
+
+  file << "\t</category>" << std::endl;
+  file << "</settings>" << std::endl;
+
+  file.close();
+
+  return true;
+}

--- a/src/settings/SettingsGenerator.h
+++ b/src/settings/SettingsGenerator.h
@@ -19,23 +19,20 @@
  */
 #pragma once
 
+#include "SettingsTypes.h"
+
 #include <string>
 
 namespace LIBRETRO
 {
-  class PathUtils
+  class CSettingsGenerator
   {
   public:
-    /*!
-     * \brief Remove the slash at the end of a path
-     *
-     * NOTE: Trailing slash causes some libretro cores to fail
-     */
-    static void RemoveSlashAtEnd(std::string& path);
+    CSettingsGenerator(const std::string& generatedDir);
 
-    /*!
-     * \brief Get the base filename, or empty if path ends in a / or \
-     */
-    static std::string GetBasename(const std::string& path);
+    bool GenerateSettings(const LibretroSettings& settings);
+
+  private:
+    std::string m_strFilePath;
   };
 }

--- a/src/settings/SettingsTypes.h
+++ b/src/settings/SettingsTypes.h
@@ -19,23 +19,30 @@
  */
 #pragma once
 
+#include "LibretroSetting.h"
+
+#include <map>
 #include <string>
+
+/*!
+ * \brief Directory name for generated settings and language files
+ */
+#define SETTINGS_GENERATED_DIRECTORY_NAME  "generated"
+
+/*!
+ * \brief File name of the generated settings.xml file
+ */
+#define SETTINGS_GENERATED_SETTINGS_NAME  "settings.xml"
+
+/*!
+ * \brief File name of the generated language file
+ */
+#define SETTINGS_GENERATED_LANGUAGE_NAME  "strings.po"
+
+#define SETTING_ID_START  30000
 
 namespace LIBRETRO
 {
-  class PathUtils
-  {
-  public:
-    /*!
-     * \brief Remove the slash at the end of a path
-     *
-     * NOTE: Trailing slash causes some libretro cores to fail
-     */
-    static void RemoveSlashAtEnd(std::string& path);
-
-    /*!
-     * \brief Get the base filename, or empty if path ends in a / or \
-     */
-    static std::string GetBasename(const std::string& path);
-  };
+  typedef std::string SettingKey;
+  typedef std::map<SettingKey, CLibretroSetting> LibretroSettings;
 }

--- a/src/utils/PathUtils.cpp
+++ b/src/utils/PathUtils.cpp
@@ -20,6 +20,8 @@
 
 #include "PathUtils.h"
 
+#include <string.h>
+
 using namespace LIBRETRO;
 
 void PathUtils::RemoveSlashAtEnd(std::string& path)
@@ -30,4 +32,19 @@ void PathUtils::RemoveSlashAtEnd(std::string& path)
     if (last == '/' || last == '\\')
       path.erase(path.size() - 1);
   }
+}
+
+std::string PathUtils::GetBasename(const std::string& path)
+{
+  char last = path[path.size() - 1];
+  if (last == '/' || last == '\\')
+    return "";
+
+  const char* s = strrchr(const_cast<char*>(path.c_str()), '/');
+  if (s == nullptr)
+    return path;
+
+  s++;
+
+  return s;
 }


### PR DESCRIPTION
This awesome change will cause the add-on to generate settings.xml and strings.po whenever the core's settings change.

Example: https://github.com/kodi-game/game.libretro.genplus/commit/784ff03