### PR TITLE
[cmake] Fix includes for Kodi headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,9 @@ find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 
-include_directories(${INCLUDES}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${KODI_INCLUDE_DIR}
                     ${kodiplatform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/src)
 
 list(APPEND DEPLIBS ${kodiplatform_LIBRARIES} ${p8-platform_LIBRARIES})

--- a/src/GameInfoLoader.cpp
+++ b/src/GameInfoLoader.cpp
@@ -21,7 +21,7 @@
 #include "GameInfoLoader.h"
 #include "log/Log.h"
 
-#include "kodi/libXBMC_addon.h"
+#include "libXBMC_addon.h"
 
 #include <stdint.h>
 

--- a/src/audio/AudioStream.cpp
+++ b/src/audio/AudioStream.cpp
@@ -21,7 +21,7 @@
 #include "AudioStream.h"
 #include "libretro/LibretroEnvironment.h"
 
-#include "kodi/libKODI_game.h"
+#include "libKODI_game.h"
 
 using namespace LIBRETRO;
 

--- a/src/audio/AudioStream.h
+++ b/src/audio/AudioStream.h
@@ -21,7 +21,7 @@
 
 #include "SingleFrameAudio.h"
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 class CHelper_libKODI_game;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -29,10 +29,10 @@
 #include "settings/Settings.h"
 #include "GameInfoLoader.h"
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_game.h"
-#include "kodi/xbmc_addon_dll.h"
-#include "kodi/kodi_game_dll.h"
+#include "libXBMC_addon.h"
+#include "libKODI_game.h"
+#include "xbmc_addon_dll.h"
+#include "kodi_game_dll.h"
 
 #include <set>
 #include <string>

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -27,7 +27,7 @@
 #include "libretro/LibretroTranslator.h"
 #include "log/Log.h"
 
-#include "kodi/libKODI_game.h"
+#include "libKODI_game.h"
 
 #include <algorithm>
 

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -21,7 +21,7 @@
 
 #include "LibretroDevice.h"
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 #include "p8-platform/threads/mutex.h"
 
 #include <stdint.h>

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 #include <map>
 #include <memory>

--- a/src/input/LibretroDeviceInput.h
+++ b/src/input/LibretroDeviceInput.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 #include "p8-platform/threads/mutex.h"
 
 #include <string>

--- a/src/libretro/ClientBridge.h
+++ b/src/libretro/ClientBridge.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 struct retro_game_info;
 

--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -24,8 +24,8 @@
 #include "input/ButtonMapper.h"
 #include "input/InputManager.h"
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_game.h"
+#include "libXBMC_addon.h"
+#include "libKODI_game.h"
 
 #include <assert.h>
 

--- a/src/libretro/LibretroDLL.cpp
+++ b/src/libretro/LibretroDLL.cpp
@@ -20,8 +20,8 @@
 
 #include "LibretroDLL.h"
 
-#include "kodi/libKODI_game.h"
-#include "kodi/kodi_game_types.h"
+#include "libKODI_game.h"
+#include "kodi_game_types.h"
 
 #ifdef _WIN32
   #include "dlfcn-win32.h" // TODO: Use file from kodi-platform

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -25,8 +25,8 @@
 #include "libretro.h"
 #include "LibretroDLL.h"
 #include "LibretroTranslator.h"
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_game.h"
+#include "libXBMC_addon.h"
+#include "libKODI_game.h"
 #include "settings/Settings.h"
 
 #include <algorithm>

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -24,7 +24,7 @@
 #include "settings/LibretroSettings.h"
 #include "video/VideoStream.h"
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 #include <map>
 #include <string>

--- a/src/libretro/LibretroResources.cpp
+++ b/src/libretro/LibretroResources.cpp
@@ -22,8 +22,8 @@
 #include "LibretroDefines.h"
 #include "utils/PathUtils.h"
 
-#include "kodi/kodi_game_types.h"
-#include "kodi/libXBMC_addon.h"
+#include "kodi_game_types.h"
+#include "libXBMC_addon.h"
 
 #include <assert.h>
 #include <utility>

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -22,7 +22,7 @@
 #include "input/LibretroDevice.h"
 #include "libretro.h"
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 #include <string>
 

--- a/src/log/LogAddon.cpp
+++ b/src/log/LogAddon.cpp
@@ -20,7 +20,7 @@
 
 #include "LogAddon.h"
 
-#include "kodi/libXBMC_addon.h"
+#include "libXBMC_addon.h"
 
 #include <assert.h>
 

--- a/src/settings/LibretroSettings.cpp
+++ b/src/settings/LibretroSettings.cpp
@@ -25,8 +25,8 @@
 #include "log/Log.h"
 #include "utils/PathUtils.h"
 
-#include "kodi/kodi_game_types.h"
-#include "kodi/libXBMC_addon.h"
+#include "kodi_game_types.h"
+#include "libXBMC_addon.h"
 
 #include <algorithm>
 #include <assert.h>

--- a/src/video/VideoStream.cpp
+++ b/src/video/VideoStream.cpp
@@ -21,7 +21,7 @@
 #include "VideoStream.h"
 #include "libretro/LibretroEnvironment.h"
 
-#include "kodi/libKODI_game.h"
+#include "libKODI_game.h"
 
 using namespace LIBRETRO;
 

--- a/src/video/VideoStream.h
+++ b/src/video/VideoStream.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "kodi/kodi_game_types.h"
+#include "kodi_game_types.h"
 
 class CHelper_libKODI_game;
 


### PR DESCRIPTION
Noticed while working on mouse support. @hudokkow has fixed this already in most of the addons. Seems to be a leftover here.

KODI_INCLUDE_DIR does already contain the 'kodi' directory. Therefore specifying it in includes only works when the headers are in a compiler default search path. Also KODI_INCLUDE_DIR has to be the first one
in order to prevent that a wrong directory propagates via kodiplatform or p8-platform. See discussion in: https://github.com/xbmc/xbmc/pull/9804

This allows to build the addon directly against a local version of Kodi (depends on kodiplatform and p8-platform being installed system wide). This is described in https://github.com/xbmc/xbmc/blob/master/project/cmake/README.md#building-binary-addons.
