### PR TITLE
[LibretroResources] Ensure that system directory exists

### DIFF
--- a/src/libretro/LibretroResources.cpp
+++ b/src/libretro/LibretroResources.cpp
@@ -56,7 +56,16 @@ void CLibretroResources::Initialize(ADDON::CHelper_libXBMC_addon* addon, const g
 
     // Set system path to first resource path discovered
     if (m_systemDirectory.empty())
+    {
       m_systemDirectory = resourcePath + "/" LIBRETRO_SYSTEM_DIRECTORY_NAME;
+
+      // Ensure folder exists
+      if (!m_addon->DirectoryExists(m_systemDirectory.c_str()))
+      {
+        dsyslog("Creating system directory: %s", m_systemDirectory.c_str());
+        m_addon->CreateDirectory(m_systemDirectory.c_str());
+      }
+    }
 
     m_resourceDirectories.push_back(std::move(resourcePath));
   }


### PR DESCRIPTION
Cores might not only want to read from it, ScummVM wants to store its configuration file into it, so it must exist.