### PR TITLE
[Fix] fix build after auto_addon_xml changes

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -213,16 +213,6 @@ ADDON_STATUS ADDON_SetSetting(const char* settingName, const void* settingValue)
   return ADDON_STATUS_OK;
 }
 
-const char* GetGameAPIVersion(void)
-{
-  return GAME_API_VERSION;
-}
-
-const char* GetMinimumGameAPIVersion(void)
-{
-  return GAME_MIN_API_VERSION;
-}
-
 GAME_ERROR LoadGame(const char* url)
 {
   if (!CLIENT)


### PR DESCRIPTION
Build is currently broken after https://github.com/xbmc/xbmc/commit/b23199b04f43c991a065884d30dc33b2b05b5dc6

```
/home/asavah/kross/src/game.libretro/src/client.cpp: In function ‘const char* GetGameAPIVersion()’:
/home/asavah/kross/src/game.libretro/src/client.cpp:218:10: error: ‘GAME_API_VERSION’ was not declared in this scope
   return GAME_API_VERSION;
          ^~~~~~~~~~~~~~~~
/home/asavah/kross/src/game.libretro/src/client.cpp:218:10: note: suggested alternative: ‘RETRO_API_VERSION’
   return GAME_API_VERSION;
          ^~~~~~~~~~~~~~~~
          RETRO_API_VERSION
/home/asavah/kross/src/game.libretro/src/client.cpp: In function ‘const char* GetMinimumGameAPIVersion()’:
/home/asavah/kross/src/game.libretro/src/client.cpp:223:10: error: ‘GAME_MIN_API_VERSION’ was not declared in this scope
   return GAME_MIN_API_VERSION;
          ^~~~~~~~~~~~~~~~~~~~
/home/asavah/kross/src/game.libretro/src/client.cpp:223:10: note: suggested alternative: ‘RETRO_API_VERSION’
   return GAME_MIN_API_VERSION;
          ^~~~~~~~~~~~~~~~~~~~
          RETRO_API_VERSION
CMakeFiles/game.libretro.dir/build.make:62: recipe for target 'CMakeFiles/game.libretro.dir/src/client.cpp.o' failed
```
Removes no longer needed functions