### PR TITLE
Buttonmap v2: Replace mapto names with libretro #defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/audio/SingleFrameAudio.cpp
                      src/GameInfoLoader.cpp
                      src/input/ButtonMapper.cpp
+                     src/input/DefaultControllerTranslator.cpp
                      src/input/InputManager.cpp
                      src/input/LibretroDevice.cpp
                      src/input/LibretroDeviceInput.cpp
@@ -43,6 +44,8 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/audio/AudioStream.h
                      src/audio/SingleFrameAudio.h
                      src/input/ButtonMapper.h
+                     src/input/DefaultControllerDefines.h
+                     src/input/DefaultControllerTranslator.h
                      src/input/InputDefinitions.h
                      src/input/InputManager.h
                      src/input/LibretroDevice.h

--- a/src/input/ButtonMapper.h
+++ b/src/input/ButtonMapper.h
@@ -24,7 +24,6 @@
 #include <string>
 
 // TODO: Make this class generic and move XML-specific stuff to xml subfolder
-class TiXmlDocument;
 class TiXmlElement;
 
 namespace LIBRETRO
@@ -48,6 +47,8 @@ namespace LIBRETRO
   private:
     bool HasController(const std::string& strControllerId) const;
     std::string GetFeature(const std::string& strControllerId, const std::string& strFeatureName) const;
+
+    bool Deserialize(TiXmlElement* pElement);
 
     bool                   m_bLoadAttempted;
     std::vector<DevicePtr> m_devices;

--- a/src/input/DefaultControllerDefines.h
+++ b/src/input/DefaultControllerDefines.h
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define DEFAULT_CONTROLLER_FEATURE_A              "a"
+#define DEFAULT_CONTROLLER_FEATURE_B              "b"
+#define DEFAULT_CONTROLLER_FEATURE_X              "x"
+#define DEFAULT_CONTROLLER_FEATURE_Y              "y"
+#define DEFAULT_CONTROLLER_FEATURE_START          "start"
+#define DEFAULT_CONTROLLER_FEATURE_BACK           "back"
+#define DEFAULT_CONTROLLER_FEATURE_UP             "up"
+#define DEFAULT_CONTROLLER_FEATURE_DOWN           "down"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT          "right"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT           "left"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT_BUMPER    "leftbumber"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT_BUMPER   "rightbumper"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT_TRIGGER   "lefttrigger"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT_TRIGGER  "righttrigger"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT_THUMB     "leftthumb"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT_THUMB    "rightthumb"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT_STICK     "leftstick"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT_STICK    "rightstick"
+#define DEFAULT_CONTROLLER_FEATURE_LEFT_MOTOR     "leftmotor"
+#define DEFAULT_CONTROLLER_FEATURE_RIGHT_MOTOR    "rightmotor"
+// Guide button not used

--- a/src/input/DefaultControllerTranslator.cpp
+++ b/src/input/DefaultControllerTranslator.cpp
@@ -1,0 +1,77 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DefaultControllerTranslator.h"
+#include "DefaultControllerDefines.h"
+#include "libretro/libretro.h"
+
+using namespace LIBRETRO;
+
+int CDefaultControllerTranslator::GetLibretroIndex(const std::string &strFeatureName)
+{
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_A)             return RETRO_DEVICE_ID_JOYPAD_A;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_B)             return RETRO_DEVICE_ID_JOYPAD_B;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_X)             return RETRO_DEVICE_ID_JOYPAD_X;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_Y)             return RETRO_DEVICE_ID_JOYPAD_Y;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_START)         return RETRO_DEVICE_ID_JOYPAD_START;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_BACK)          return RETRO_DEVICE_ID_JOYPAD_SELECT;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT_BUMPER)   return RETRO_DEVICE_ID_JOYPAD_L;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT_BUMPER)  return RETRO_DEVICE_ID_JOYPAD_R;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT_THUMB)    return RETRO_DEVICE_ID_JOYPAD_L3;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT_THUMB)   return RETRO_DEVICE_ID_JOYPAD_R3;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_UP)            return RETRO_DEVICE_ID_JOYPAD_UP;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_DOWN)          return RETRO_DEVICE_ID_JOYPAD_DOWN;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT)         return RETRO_DEVICE_ID_JOYPAD_RIGHT;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT)          return RETRO_DEVICE_ID_JOYPAD_LEFT;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT_TRIGGER)  return RETRO_DEVICE_ID_JOYPAD_L2;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT_TRIGGER) return RETRO_DEVICE_ID_JOYPAD_R2;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT_STICK)    return RETRO_DEVICE_INDEX_ANALOG_LEFT;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT_STICK)   return RETRO_DEVICE_INDEX_ANALOG_RIGHT;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_LEFT_MOTOR)    return RETRO_RUMBLE_STRONG;
+  if (strFeatureName == DEFAULT_CONTROLLER_FEATURE_RIGHT_MOTOR)   return RETRO_RUMBLE_WEAK;
+
+  return -1;
+}
+
+std::string CDefaultControllerTranslator::GetControllerFeature(const std::string &strLibretroFeature)
+{
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_A")        return DEFAULT_CONTROLLER_FEATURE_A;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_B")        return DEFAULT_CONTROLLER_FEATURE_B;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_X")        return DEFAULT_CONTROLLER_FEATURE_X;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_Y")        return DEFAULT_CONTROLLER_FEATURE_Y;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_START")    return DEFAULT_CONTROLLER_FEATURE_START;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_SELECT")   return DEFAULT_CONTROLLER_FEATURE_BACK;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_UP")       return DEFAULT_CONTROLLER_FEATURE_UP;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_DOWN")     return DEFAULT_CONTROLLER_FEATURE_DOWN;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_RIGHT")    return DEFAULT_CONTROLLER_FEATURE_RIGHT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_LEFT")     return DEFAULT_CONTROLLER_FEATURE_LEFT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L")        return DEFAULT_CONTROLLER_FEATURE_LEFT_BUMPER;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R")        return DEFAULT_CONTROLLER_FEATURE_RIGHT_BUMPER;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L2")       return DEFAULT_CONTROLLER_FEATURE_LEFT_TRIGGER;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R2")       return DEFAULT_CONTROLLER_FEATURE_RIGHT_TRIGGER;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L3")       return DEFAULT_CONTROLLER_FEATURE_LEFT_THUMB;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R3")       return DEFAULT_CONTROLLER_FEATURE_RIGHT_THUMB;
+  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_LEFT")  return DEFAULT_CONTROLLER_FEATURE_LEFT_STICK;
+  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_RIGHT") return DEFAULT_CONTROLLER_FEATURE_RIGHT_STICK;
+  if (strLibretroFeature == "RETRO_RUMBLE_STRONG")             return DEFAULT_CONTROLLER_FEATURE_LEFT_MOTOR;
+  if (strLibretroFeature == "RETRO_RUMBLE_WEAK")               return DEFAULT_CONTROLLER_FEATURE_RIGHT_MOTOR;
+
+  return "";
+}

--- a/src/input/DefaultControllerTranslator.h
+++ b/src/input/DefaultControllerTranslator.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2015-2016 Team Kodi
+ *      Copyright (C) 2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,15 +19,25 @@
  */
 #pragma once
 
-#define BUTTONMAP_XML_ROOT                  "buttonmap"
+#include <string>
 
-#define BUTTONMAP_XML_ELM_CONTROLLER        "controller"
-#define BUTTONMAP_XML_ELM_FEATURE           "feature"
+namespace LIBRETRO
+{
+  class CDefaultControllerTranslator
+  {
+  public:
+    /*!
+     * \brief Translate from Kodi feature name to libretro index
+     */
+    static int GetLibretroIndex(const std::string &strFeatureName);
 
-#define BUTTONMAP_XML_ATTR_VERSION          "version"
-
-#define BUTTONMAP_XML_ATTR_CONTROLLER_ID    "id"
-#define BUTTONMAP_XML_ATTR_CONTROLLER_TYPE  "type"
-
-#define BUTTONMAP_XML_ATTR_FEATURE_NAME     "name"
-#define BUTTONMAP_XML_ATTR_FEATURE_MAPTO    "mapto"
+    /*!
+     * \brief Translate from libretro feature (from libretro.h) to Kodi feature
+     *
+     * This is necessary because input doesn't just flow from Kodi to the
+     * add-on. Rumble feedback going from the add-on to Kodi makes use of this
+     * functionality.
+     */
+    static std::string GetControllerFeature(const std::string &strLibretroFeature);
+  };
+}

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -48,7 +48,7 @@ namespace LIBRETRO
     const FeatureMap& Features(void) const { return m_featureMap; }
     CLibretroDeviceInput& Input() { return *m_input; }
 
-    bool Deserialize(const TiXmlElement* pElement);
+    bool Deserialize(const TiXmlElement* pElement, unsigned int buttonMapVersion);
 
   private:
     std::string                            m_controllerId;

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -81,7 +81,7 @@ GAME_HW_CONTEXT_TYPE LibretroTranslator::GetHWContextType(retro_hw_context_type 
 
 // --- Input translation --------------------------------------------------
 
-libretro_device_t LibretroTranslator::GetDeviceType(const std::string& strType)
+libretro_device_t LibretroTranslator::GetDeviceTypeV1(const std::string& strType)
 {
   if (strType == "joypad")   return RETRO_DEVICE_JOYPAD;
   if (strType == "mouse")    return RETRO_DEVICE_MOUSE;
@@ -93,16 +93,28 @@ libretro_device_t LibretroTranslator::GetDeviceType(const std::string& strType)
   return RETRO_DEVICE_NONE;
 }
 
+libretro_device_t LibretroTranslator::GetDeviceTypeV2(const std::string& strLibretroType)
+{
+  if (strLibretroType == "RETRO_DEVICE_JOYPAD")   return RETRO_DEVICE_JOYPAD;
+  if (strLibretroType == "RETRO_DEVICE_MOUSE")    return RETRO_DEVICE_MOUSE;
+  if (strLibretroType == "RETRO_DEVICE_KEYBOARD") return RETRO_DEVICE_KEYBOARD;
+  if (strLibretroType == "RETRO_DEVICE_LIGHTGUN") return RETRO_DEVICE_LIGHTGUN;
+  if (strLibretroType == "RETRO_DEVICE_ANALOG")   return RETRO_DEVICE_ANALOG;
+  if (strLibretroType == "RETRO_DEVICE_POINTER")  return RETRO_DEVICE_POINTER;
+
+  return RETRO_DEVICE_NONE;
+}
+
 const char* LibretroTranslator::GetDeviceName(libretro_device_t type)
 {
   switch (type)
   {
-  case RETRO_DEVICE_JOYPAD:   return "joypad";
-  case RETRO_DEVICE_MOUSE:    return "mouse";
-  case RETRO_DEVICE_KEYBOARD: return "keyboard";
-  case RETRO_DEVICE_LIGHTGUN: return "lightgun";
-  case RETRO_DEVICE_ANALOG:   return "analog";
-  case RETRO_DEVICE_POINTER:  return "pointer";
+  case RETRO_DEVICE_JOYPAD:   return "RETRO_DEVICE_JOYPAD";
+  case RETRO_DEVICE_MOUSE:    return "RETRO_DEVICE_MOUSE";
+  case RETRO_DEVICE_KEYBOARD: return "RETRO_DEVICE_KEYBOARD";
+  case RETRO_DEVICE_LIGHTGUN: return "RETRO_DEVICE_LIGHTGUN";
+  case RETRO_DEVICE_ANALOG:   return "RETRO_DEVICE_ANALOG";
+  case RETRO_DEVICE_POINTER:  return "RETRO_DEVICE_POINTER";
   default:
     break;
   }
@@ -110,42 +122,68 @@ const char* LibretroTranslator::GetDeviceName(libretro_device_t type)
   return "";
 }
 
-int LibretroTranslator::GetFeatureIndex(const std::string& strFeatureName)
+std::string LibretroTranslator::GetFeatureV2(const std::string& strLibretroFeature)
 {
-  if (strFeatureName == "a")            return RETRO_DEVICE_ID_JOYPAD_A;
-  if (strFeatureName == "b")            return RETRO_DEVICE_ID_JOYPAD_B;
-  if (strFeatureName == "x")            return RETRO_DEVICE_ID_JOYPAD_X;
-  if (strFeatureName == "y")            return RETRO_DEVICE_ID_JOYPAD_Y;
-  if (strFeatureName == "start")        return RETRO_DEVICE_ID_JOYPAD_START;
-  if (strFeatureName == "select")       return RETRO_DEVICE_ID_JOYPAD_SELECT;
-  if (strFeatureName == "up")           return RETRO_DEVICE_ID_JOYPAD_UP;
-  if (strFeatureName == "down")         return RETRO_DEVICE_ID_JOYPAD_DOWN;
-  if (strFeatureName == "right")        return RETRO_DEVICE_ID_JOYPAD_RIGHT;
-  if (strFeatureName == "left")         return RETRO_DEVICE_ID_JOYPAD_LEFT;
-  if (strFeatureName == "l")            return RETRO_DEVICE_ID_JOYPAD_L;
-  if (strFeatureName == "r")            return RETRO_DEVICE_ID_JOYPAD_R;
-  if (strFeatureName == "l2")           return RETRO_DEVICE_ID_JOYPAD_L2;
-  if (strFeatureName == "r2")           return RETRO_DEVICE_ID_JOYPAD_R2;
-  if (strFeatureName == "l3")           return RETRO_DEVICE_ID_JOYPAD_L3;
-  if (strFeatureName == "r3")           return RETRO_DEVICE_ID_JOYPAD_R3;
-  if (strFeatureName == "leftstick")    return RETRO_DEVICE_INDEX_ANALOG_LEFT;
-  if (strFeatureName == "rightstick")   return RETRO_DEVICE_INDEX_ANALOG_RIGHT;
-  if (strFeatureName == "relpointer")   return 0; // Only 1 relative pointer
-  if (strFeatureName == "leftmouse")    return RETRO_DEVICE_ID_MOUSE_LEFT;
-  if (strFeatureName == "rightmouse")   return RETRO_DEVICE_ID_MOUSE_RIGHT;
-  if (strFeatureName == "wheelup")      return RETRO_DEVICE_ID_MOUSE_WHEELUP;
-  if (strFeatureName == "wheeldown")    return RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
-  if (strFeatureName == "middle")       return RETRO_DEVICE_ID_MOUSE_MIDDLE;
-  if (strFeatureName == "horizwheelup") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
-  if (strFeatureName == "horizwheeldown") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
-  if (strFeatureName == "gunpointer")   return 0; // Only 1 relative pointer
-  if (strFeatureName == "trigger")      return RETRO_DEVICE_ID_LIGHTGUN_TRIGGER;
-  if (strFeatureName == "cursor")       return RETRO_DEVICE_ID_LIGHTGUN_CURSOR;
-  if (strFeatureName == "turbo")        return RETRO_DEVICE_ID_LIGHTGUN_TURBO;
-  if (strFeatureName == "pause")        return RETRO_DEVICE_ID_LIGHTGUN_PAUSE;
-  if (strFeatureName == "gunstart")     return RETRO_DEVICE_ID_LIGHTGUN_START;
-  if (strFeatureName == "strong")       return RETRO_RUMBLE_STRONG;
-  if (strFeatureName == "weak")         return RETRO_RUMBLE_WEAK;
+  if (strLibretroFeature == "a")           return "RETRO_DEVICE_ID_JOYPAD_A";
+  if (strLibretroFeature == "b")           return "RETRO_DEVICE_ID_JOYPAD_B";
+  if (strLibretroFeature == "x")           return "RETRO_DEVICE_ID_JOYPAD_X";
+  if (strLibretroFeature == "y")           return "RETRO_DEVICE_ID_JOYPAD_Y";
+  if (strLibretroFeature == "start")       return "RETRO_DEVICE_ID_JOYPAD_START";
+  if (strLibretroFeature == "select")      return "RETRO_DEVICE_ID_JOYPAD_SELECT";
+  if (strLibretroFeature == "up")          return "RETRO_DEVICE_ID_JOYPAD_UP";
+  if (strLibretroFeature == "down")        return "RETRO_DEVICE_ID_JOYPAD_DOWN";
+  if (strLibretroFeature == "right")       return "RETRO_DEVICE_ID_JOYPAD_RIGHT";
+  if (strLibretroFeature == "left")        return "RETRO_DEVICE_ID_JOYPAD_LEFT";
+  if (strLibretroFeature == "l")           return "RETRO_DEVICE_ID_JOYPAD_L";
+  if (strLibretroFeature == "r")           return "RETRO_DEVICE_ID_JOYPAD_R";
+  if (strLibretroFeature == "l2")          return "RETRO_DEVICE_ID_JOYPAD_L2";
+  if (strLibretroFeature == "r2")          return "RETRO_DEVICE_ID_JOYPAD_R2";
+  if (strLibretroFeature == "l3")          return "RETRO_DEVICE_ID_JOYPAD_L3";
+  if (strLibretroFeature == "r3")          return "RETRO_DEVICE_ID_JOYPAD_R3";
+  if (strLibretroFeature == "leftstick")   return "RETRO_DEVICE_INDEX_ANALOG_LEFT";
+  if (strLibretroFeature == "rightstick")  return "RETRO_DEVICE_INDEX_ANALOG_RIGHT";
+  if (strLibretroFeature == "strong")      return "RETRO_RUMBLE_STRONG";
+  if (strLibretroFeature == "weak")        return "RETRO_RUMBLE_WEAK";
+
+  return "";
+}
+
+int LibretroTranslator::GetFeatureIndexV2(const std::string& strLibretroFeature)
+{
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_A")              return RETRO_DEVICE_ID_JOYPAD_A;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_B")              return RETRO_DEVICE_ID_JOYPAD_B;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_X")              return RETRO_DEVICE_ID_JOYPAD_X;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_Y")              return RETRO_DEVICE_ID_JOYPAD_Y;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_START")          return RETRO_DEVICE_ID_JOYPAD_START;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_SELECT")         return RETRO_DEVICE_ID_JOYPAD_SELECT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_UP")             return RETRO_DEVICE_ID_JOYPAD_UP;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_DOWN")           return RETRO_DEVICE_ID_JOYPAD_DOWN;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_RIGHT")          return RETRO_DEVICE_ID_JOYPAD_RIGHT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_LEFT")           return RETRO_DEVICE_ID_JOYPAD_LEFT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L")              return RETRO_DEVICE_ID_JOYPAD_L;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R")              return RETRO_DEVICE_ID_JOYPAD_R;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L2")             return RETRO_DEVICE_ID_JOYPAD_L2;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R2")             return RETRO_DEVICE_ID_JOYPAD_R2;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L3")             return RETRO_DEVICE_ID_JOYPAD_L3;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R3")             return RETRO_DEVICE_ID_JOYPAD_R3;
+  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_LEFT")        return RETRO_DEVICE_INDEX_ANALOG_LEFT;
+  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_RIGHT")       return RETRO_DEVICE_INDEX_ANALOG_RIGHT;
+  if (strLibretroFeature == "RETRO_DEVICE_MOUSE")                    return 0; // Only 1 relative pointer
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_LEFT")            return RETRO_DEVICE_ID_MOUSE_LEFT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_RIGHT")           return RETRO_DEVICE_ID_MOUSE_RIGHT;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_WHEELUP")         return RETRO_DEVICE_ID_MOUSE_WHEELUP;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_WHEELDOWN")       return RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_MIDDLE")          return RETRO_DEVICE_ID_MOUSE_MIDDLE;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP")   return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
+  if (strLibretroFeature == "RETRO_DEVICE_LIGHTGUN")                 return 0; // Only 1 relative pointer
+  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_TRIGGER")      return RETRO_DEVICE_ID_LIGHTGUN_TRIGGER;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_CURSOR")       return RETRO_DEVICE_ID_LIGHTGUN_CURSOR;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_TURBO")        return RETRO_DEVICE_ID_LIGHTGUN_TURBO;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_PAUSE")        return RETRO_DEVICE_ID_LIGHTGUN_PAUSE;
+  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_START")        return RETRO_DEVICE_ID_LIGHTGUN_START;
+  if (strLibretroFeature == "RETRO_RUMBLE_STRONG")                   return RETRO_RUMBLE_STRONG;
+  if (strLibretroFeature == "RETRO_RUMBLE_WEAK")                     return RETRO_RUMBLE_WEAK;
 
   return -1;
 }
@@ -158,22 +196,22 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
   {
     switch (id)
     {
-    case RETRO_DEVICE_ID_JOYPAD_B:        return "b";
-    case RETRO_DEVICE_ID_JOYPAD_Y:        return "y";
-    case RETRO_DEVICE_ID_JOYPAD_SELECT:   return "select";
-    case RETRO_DEVICE_ID_JOYPAD_START:    return "start";
-    case RETRO_DEVICE_ID_JOYPAD_UP:       return "up";
-    case RETRO_DEVICE_ID_JOYPAD_DOWN:     return "down";
-    case RETRO_DEVICE_ID_JOYPAD_LEFT:     return "left";
-    case RETRO_DEVICE_ID_JOYPAD_RIGHT:    return "right";
-    case RETRO_DEVICE_ID_JOYPAD_A:        return "a";
-    case RETRO_DEVICE_ID_JOYPAD_X:        return "x";
-    case RETRO_DEVICE_ID_JOYPAD_L:        return "l";
-    case RETRO_DEVICE_ID_JOYPAD_R:        return "r";
-    case RETRO_DEVICE_ID_JOYPAD_L2:       return "l2";
-    case RETRO_DEVICE_ID_JOYPAD_R2:       return "r2";
-    case RETRO_DEVICE_ID_JOYPAD_L3:       return "l3";
-    case RETRO_DEVICE_ID_JOYPAD_R3:       return "r3";
+    case RETRO_DEVICE_ID_JOYPAD_B:        return "RETRO_DEVICE_ID_JOYPAD_B";
+    case RETRO_DEVICE_ID_JOYPAD_Y:        return "RETRO_DEVICE_ID_JOYPAD_Y";
+    case RETRO_DEVICE_ID_JOYPAD_SELECT:   return "RETRO_DEVICE_ID_JOYPAD_SELECT";
+    case RETRO_DEVICE_ID_JOYPAD_START:    return "RETRO_DEVICE_ID_JOYPAD_START";
+    case RETRO_DEVICE_ID_JOYPAD_UP:       return "RETRO_DEVICE_ID_JOYPAD_UP";
+    case RETRO_DEVICE_ID_JOYPAD_DOWN:     return "RETRO_DEVICE_ID_JOYPAD_DOWN";
+    case RETRO_DEVICE_ID_JOYPAD_LEFT:     return "RETRO_DEVICE_ID_JOYPAD_LEFT";
+    case RETRO_DEVICE_ID_JOYPAD_RIGHT:    return "RETRO_DEVICE_ID_JOYPAD_RIGHT";
+    case RETRO_DEVICE_ID_JOYPAD_A:        return "RETRO_DEVICE_ID_JOYPAD_A";
+    case RETRO_DEVICE_ID_JOYPAD_X:        return "RETRO_DEVICE_ID_JOYPAD_X";
+    case RETRO_DEVICE_ID_JOYPAD_L:        return "RETRO_DEVICE_ID_JOYPAD_L";
+    case RETRO_DEVICE_ID_JOYPAD_R:        return "RETRO_DEVICE_ID_JOYPAD_R";
+    case RETRO_DEVICE_ID_JOYPAD_L2:       return "RETRO_DEVICE_ID_JOYPAD_L2";
+    case RETRO_DEVICE_ID_JOYPAD_R2:       return "RETRO_DEVICE_ID_JOYPAD_R2";
+    case RETRO_DEVICE_ID_JOYPAD_L3:       return "RETRO_DEVICE_ID_JOYPAD_L3";
+    case RETRO_DEVICE_ID_JOYPAD_R3:       return "RETRO_DEVICE_ID_JOYPAD_R3";
     default:
       break;
     }
@@ -185,15 +223,15 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
     {
     case RETRO_DEVICE_ID_MOUSE_X:
     case RETRO_DEVICE_ID_MOUSE_Y:
-      return "relpointer";
+      return "RETRO_DEVICE_MOUSE";
 
-    case RETRO_DEVICE_ID_MOUSE_LEFT:             return "leftmouse";
-    case RETRO_DEVICE_ID_MOUSE_RIGHT:            return "rightmouse";
-    case RETRO_DEVICE_ID_MOUSE_WHEELUP:          return "wheelup";
-    case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:        return "wheeldown";
-    case RETRO_DEVICE_ID_MOUSE_MIDDLE:           return "middle";
-    case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:    return "horizwheelup";
-    case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:  return "horizwheeldown";
+    case RETRO_DEVICE_ID_MOUSE_LEFT:             return "RETRO_DEVICE_ID_MOUSE_LEFT";
+    case RETRO_DEVICE_ID_MOUSE_RIGHT:            return "RETRO_DEVICE_ID_MOUSE_RIGHT";
+    case RETRO_DEVICE_ID_MOUSE_WHEELUP:          return "RETRO_DEVICE_ID_MOUSE_WHEELUP";
+    case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:        return "RETRO_DEVICE_ID_MOUSE_WHEELDOWN";
+    case RETRO_DEVICE_ID_MOUSE_MIDDLE:           return "RETRO_DEVICE_ID_MOUSE_MIDDLE";
+    case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:    return "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP";
+    case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:  return "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN";
     default:
       break;
     }
@@ -209,13 +247,13 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
     {
     case RETRO_DEVICE_ID_LIGHTGUN_X:
     case RETRO_DEVICE_ID_LIGHTGUN_Y:
-      return "gunpointer";
+      return "RETRO_DEVICE_LIGHTGUN";
 
-    case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:  return "trigger";
-    case RETRO_DEVICE_ID_LIGHTGUN_CURSOR:   return "cursor";
-    case RETRO_DEVICE_ID_LIGHTGUN_TURBO:    return "turbo";
-    case RETRO_DEVICE_ID_LIGHTGUN_PAUSE:    return "pause";
-    case RETRO_DEVICE_ID_LIGHTGUN_START:    return "gunstart";
+    case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:  return "RETRO_DEVICE_ID_LIGHTGUN_TRIGGER";
+    case RETRO_DEVICE_ID_LIGHTGUN_CURSOR:   return "RETRO_DEVICE_ID_LIGHTGUN_CURSOR";
+    case RETRO_DEVICE_ID_LIGHTGUN_TURBO:    return "RETRO_DEVICE_ID_LIGHTGUN_TURBO";
+    case RETRO_DEVICE_ID_LIGHTGUN_PAUSE:    return "RETRO_DEVICE_ID_LIGHTGUN_PAUSE";
+    case RETRO_DEVICE_ID_LIGHTGUN_START:    return "RETRO_DEVICE_ID_LIGHTGUN_START";
     default:
       break;
     }
@@ -230,8 +268,8 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
     {
       switch (index)
       {
-      case RETRO_DEVICE_INDEX_ANALOG_LEFT:  return "leftstick";
-      case RETRO_DEVICE_INDEX_ANALOG_RIGHT: return "rightstick";
+      case RETRO_DEVICE_INDEX_ANALOG_LEFT:  return "RETRO_DEVICE_INDEX_ANALOG_LEFT";
+      case RETRO_DEVICE_INDEX_ANALOG_RIGHT: return "RETRO_DEVICE_INDEX_ANALOG_RIGHT";
       default:
         break;
       }
@@ -261,8 +299,8 @@ const char* LibretroTranslator::GetComponentName(libretro_device_t type, unsigne
   {
     switch (id)
     {
-    case RETRO_DEVICE_ID_ANALOG_X:  return "x";
-    case RETRO_DEVICE_ID_ANALOG_Y:  return "y";
+    case RETRO_DEVICE_ID_ANALOG_X:  return "RETRO_DEVICE_ID_ANALOG_X";
+    case RETRO_DEVICE_ID_ANALOG_Y:  return "RETRO_DEVICE_ID_ANALOG_Y";
     default:
       break;
     }
@@ -272,8 +310,8 @@ const char* LibretroTranslator::GetComponentName(libretro_device_t type, unsigne
   {
     switch (id)
     {
-    case RETRO_DEVICE_ID_MOUSE_X:  return "x";
-    case RETRO_DEVICE_ID_MOUSE_Y:  return "y";
+    case RETRO_DEVICE_ID_MOUSE_X:  return "RETRO_DEVICE_ID_MOUSE_X";
+    case RETRO_DEVICE_ID_MOUSE_Y:  return "RETRO_DEVICE_ID_MOUSE_Y";
     default:
       break;
     }
@@ -283,8 +321,8 @@ const char* LibretroTranslator::GetComponentName(libretro_device_t type, unsigne
   {
     switch (id)
     {
-    case RETRO_DEVICE_ID_LIGHTGUN_X:  return "x";
-    case RETRO_DEVICE_ID_LIGHTGUN_Y:  return "y";
+    case RETRO_DEVICE_ID_LIGHTGUN_X:  return "RETRO_DEVICE_ID_LIGHTGUN_X";
+    case RETRO_DEVICE_ID_LIGHTGUN_Y:  return "RETRO_DEVICE_ID_LIGHTGUN_Y";
     default:
       break;
     }
@@ -294,8 +332,8 @@ const char* LibretroTranslator::GetComponentName(libretro_device_t type, unsigne
   {
     switch (id)
     {
-    case RETRO_DEVICE_ID_POINTER_X:  return "x";
-    case RETRO_DEVICE_ID_POINTER_Y:  return "y";
+    case RETRO_DEVICE_ID_POINTER_X:  return "RETRO_DEVICE_ID_POINTER_X";
+    case RETRO_DEVICE_ID_POINTER_Y:  return "RETRO_DEVICE_ID_POINTER_Y";
     default:
       break;
     }
@@ -312,8 +350,8 @@ std::string LibretroTranslator::GetMotorName(retro_rumble_effect effect)
 {
   switch (effect)
   {
-    case RETRO_RUMBLE_STRONG: return "strong";
-    case RETRO_RUMBLE_WEAK:   return "weak";
+    case RETRO_RUMBLE_STRONG: return "RETRO_RUMBLE_STRONG";
+    case RETRO_RUMBLE_WEAK:   return "RETRO_RUMBLE_WEAK";
     default:
       break;
   }

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -68,11 +68,18 @@ namespace LIBRETRO
     // --- Input translation --------------------------------------------------
 
     /*!
+     * \brief Translate device type (libretro buttonmap "type" field) from version 1
+     * \param strType The device type to translate from a buttonmap at version 1
+     * \return The translated device type
+     */
+    static libretro_device_t GetDeviceTypeV1(const std::string& strType);
+
+    /*!
      * \brief Translate device type (Game API to libretro).
      * \param strType The device type to translate.
      * \return Translated device values.
      */
-    static libretro_device_t GetDeviceType(const std::string& strType);
+    static libretro_device_t GetDeviceTypeV2(const std::string& strLibretroType);
 
     /*!
      * \brief Translate device type (libretro) to string representation (e.g. for logging).
@@ -82,11 +89,18 @@ namespace LIBRETRO
     static const char* GetDeviceName(libretro_device_t type);
 
     /*!
+     * \brief Translate button/feature name (libretro buttonmap "mapto" field) from version 1 to version 2
+     * \param strFeatureName The feature name to translate from a buttonmap at version 1.
+     * \return The feature name for the buttonmap at version 2+.
+     */
+    static std::string GetFeatureV2(const std::string& strLibretroFeature);
+
+    /*!
      * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.
      * \param strFeatureName The feature name to translate.
      * \return Translated button/feature id.
      */
-    static int GetFeatureIndex(const std::string& strFeatureName);
+    static int GetFeatureIndexV2(const std::string& strLibretroFeature);
 
     /*!
      * \brief Translate identifiers to feature name (libretro buttonmap "mapto" field).


### PR DESCRIPTION
This updates the buttonmap syntax to use #defines from libretro.h instead of short, easy-to-read names.

The downside of the easy-to-read names was that it introduced another layer. Ultimately, we need to translate the Kodi feature to the constants in libretro.h. By using the #defines directly, there will be less confusion from the unnecessary layer.

Before:

```xml
<buttonmap>
  <controller id="game.controller.snes" type="joypad">
    <feature name="a" mapto="a"/>
    <feature name="b" mapto="b"/>
    <feature name="x" mapto="x"/>
    <feature name="y" mapto="y"/>
    <feature name="start" mapto="start"/>
    <feature name="select" mapto="select"/>
    <feature name="up" mapto="up"/>
    <feature name="down" mapto="down"/>
    <feature name="right" mapto="right"/>
    <feature name="left" mapto="left"/>
    <feature name="rightbumper" mapto="r"/>
    <feature name="leftbumper" mapto="l"/>
  </controller>
</buttonmap>
```

After:

```xml
<buttonmap version="2">
  <controller id="game.controller.snes" type="RETRO_DEVICE_JOYPAD">
    <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
    <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
    <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
    <feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
    <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
    <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
    <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
    <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
    <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
    <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
    <feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
  </controller>
</buttonmap>
```