### PR TITLE
[Game API] Update to v1.0.34: Wheel and throttle support

### DIFF
--- a/src/input/ButtonMapper.cpp
+++ b/src/input/ButtonMapper.cpp
@@ -115,6 +115,30 @@ int CButtonMapper::GetLibretroIndex(const std::string& strControllerId, const st
   return -1;
 }
 
+libretro_device_t CButtonMapper::GetLibretroDevice(const std::string& strControllerId, const std::string& strFeatureName) const
+{
+  if (!strControllerId.empty() && !strFeatureName.empty())
+  {
+    std::string mapto = GetFeature(strControllerId, strFeatureName);
+    if (!mapto.empty())
+      return LibretroTranslator::GetLibretroDevice(mapto);
+  }
+
+  return RETRO_DEVICE_NONE;
+}
+
+int CButtonMapper::GetAxisID(const std::string& strControllerId, const std::string& strFeatureName) const
+{
+  if (!strControllerId.empty() && !strFeatureName.empty())
+  {
+    std::string axis = GetAxis(strControllerId, strFeatureName);
+    if (!axis.empty())
+      return LibretroTranslator::GetAxisID(axis);
+  }
+
+  return -1;
+}
+
 std::string CButtonMapper::GetControllerFeature(const std::string& strControllerId, const std::string& strLibretroFeature)
 {
   std::string feature;
@@ -133,7 +157,7 @@ std::string CButtonMapper::GetControllerFeature(const std::string& strController
         for (auto& featurePair : features)
         {
           const std::string& controllerFeature = featurePair.first;
-          const std::string& libretroFeature = featurePair.second;
+          const std::string& libretroFeature = featurePair.second.feature;
 
           if (libretroFeature == strLibretroFeature)
           {
@@ -177,7 +201,7 @@ std::string CButtonMapper::GetFeature(const std::string& strControllerId, const 
       for (auto& featurePair : features)
       {
         const std::string& controllerFeature = featurePair.first;
-        const std::string& libretroFeature = featurePair.second;
+        const std::string& libretroFeature = featurePair.second.feature;
 
         if (controllerFeature == strFeatureName)
         {
@@ -190,6 +214,33 @@ std::string CButtonMapper::GetFeature(const std::string& strControllerId, const 
   }
 
   return mapto;
+}
+
+std::string CButtonMapper::GetAxis(const std::string& strControllerId, const std::string& strFeatureName) const
+{
+  std::string axis;
+
+  for (auto& device : m_devices)
+  {
+    if (device->ControllerID() == strControllerId)
+    {
+      const FeatureMap& features = device->Features();
+      for (auto& featurePair : features)
+      {
+        const std::string& controllerFeature = featurePair.first;
+        const std::string& libretroAxis = featurePair.second.axis;
+
+        if (controllerFeature == strFeatureName)
+        {
+          axis = libretroAxis;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  return axis;
 }
 
 bool CButtonMapper::Deserialize(TiXmlElement* pElement)

--- a/src/input/ButtonMapper.h
+++ b/src/input/ButtonMapper.h
@@ -41,12 +41,15 @@ namespace LIBRETRO
     libretro_device_t GetLibretroType(const std::string& strControllerId);
 
     int GetLibretroIndex(const std::string& strControllerId, const std::string& strFeatureName);
+    libretro_device_t GetLibretroDevice(const std::string& strControllerId, const std::string& strFeatureName) const;
+    int GetAxisID(const std::string& strControllerId, const std::string& strFeatureName) const;
 
     std::string GetControllerFeature(const std::string& strControllerId, const std::string& strLibretroFeature);
 
   private:
     bool HasController(const std::string& strControllerId) const;
     std::string GetFeature(const std::string& strControllerId, const std::string& strFeatureName) const;
+    std::string GetAxis(const std::string& strControllerId, const std::string& strFeatureName) const;
 
     bool Deserialize(TiXmlElement* pElement);
 

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -31,3 +31,4 @@
 
 #define BUTTONMAP_XML_ATTR_FEATURE_NAME     "name"
 #define BUTTONMAP_XML_ATTR_FEATURE_MAPTO    "mapto"
+#define BUTTONMAP_XML_ATTR_FEATURE_AXIS     "axis"

--- a/src/input/LibretroDevice.cpp
+++ b/src/input/LibretroDevice.cpp
@@ -100,18 +100,32 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
       return false;
     }
 
-    std::string libretroFeature;
+    const char* axis = pFeature->Attribute(BUTTONMAP_XML_ATTR_FEATURE_AXIS);
+
+    FeatureMapItem libretroFeature;
 
     if (buttonMapVersion == 1)
-      libretroFeature = LibretroTranslator::GetFeatureV2(mapto);
+      libretroFeature.feature = LibretroTranslator::GetFeatureV2(mapto);
     else
-      libretroFeature = mapto;
+      libretroFeature.feature = mapto;
 
     // Ensure feature is valid
-    if (LibretroTranslator::GetFeatureIndexV2(libretroFeature) < 0)
+    if (LibretroTranslator::GetFeatureIndexV2(libretroFeature.feature) < 0)
     {
       esyslog("<%s> tag has invalid \"%s\" attribute: \"%s\"", BUTTONMAP_XML_ELM_FEATURE, BUTTONMAP_XML_ATTR_FEATURE_MAPTO, mapto);
       return false;
+    }
+
+    if (axis != nullptr)
+    {
+      libretroFeature.axis = axis;
+
+      // Ensure axis is valid
+      if (LibretroTranslator::GetAxisID(libretroFeature.axis) < 0)
+      {
+        esyslog("<%s> tag has invalid \"%s\" attribute: \"%s\"", BUTTONMAP_XML_ELM_FEATURE, BUTTONMAP_XML_ATTR_FEATURE_AXIS, axis);
+        return false;
+      }
     }
 
     m_featureMap[name] = std::move(libretroFeature);

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -33,7 +33,14 @@ namespace LIBRETRO
   class CLibretroDevice;
   typedef std::shared_ptr<CLibretroDevice>   DevicePtr;
   typedef unsigned int                       libretro_device_t;
-  typedef std::map<std::string, std::string> FeatureMap;
+
+  struct FeatureMapItem
+  {
+    std::string feature;
+    std::string axis;
+  };
+
+  using FeatureMap = std::map<std::string, FeatureMapItem>;
 
   class CLibretroDeviceInput;
 

--- a/src/input/LibretroDeviceInput.cpp
+++ b/src/input/LibretroDeviceInput.cpp
@@ -201,6 +201,60 @@ bool CLibretroDeviceInput::InputEvent(const game_input_event& event)
         break;
       }
 
+      case GAME_INPUT_EVENT_AXIS:
+      {
+        const int axisId = CButtonMapper::Get().GetAxisID(strControllerId, strFeatureName);
+        if (axisId >= 0)
+        {
+          const libretro_device_t deviceType = CButtonMapper::Get().GetLibretroDevice(strControllerId, strFeatureName);
+          switch (deviceType)
+          {
+          case RETRO_DEVICE_ANALOG:
+          {
+            if (index < static_cast<int>(m_analogSticks.size()))
+            {
+              auto& analogStick = m_analogSticks[index];
+              switch (axisId)
+              {
+              case RETRO_DEVICE_ID_ANALOG_X:
+                analogStick.x = event.axis.position;
+                break;
+              case RETRO_DEVICE_ID_ANALOG_Y:
+                analogStick.y = event.axis.position;
+                break;
+              default:
+                break;
+              }
+            }
+            break;
+          }
+          case RETRO_DEVICE_POINTER:
+          {
+            if (index < static_cast<int>(m_absolutePointers.size()))
+            {
+              auto& absPointer = m_absolutePointers[index];
+              switch (axisId)
+              {
+              case RETRO_DEVICE_ID_POINTER_X:
+                absPointer.x = event.axis.position;
+                break;
+              case RETRO_DEVICE_ID_POINTER_Y:
+                absPointer.y = event.axis.position;
+                break;
+              default:
+                break;
+              }
+            }
+            break;
+          }
+          default:
+            break;
+          }
+        }
+
+        break;
+      }
+
       case GAME_INPUT_EVENT_ANALOG_STICK:
         if (index < (int)m_analogSticks.size())
           m_analogSticks[index] = event.analog_stick;

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -20,6 +20,8 @@
 
 #include "LibretroTranslator.h"
 
+#include <algorithm>
+
 using namespace LIBRETRO;
 
 namespace LIBRETRO
@@ -147,44 +149,116 @@ std::string LibretroTranslator::GetFeatureV2(const std::string& strLibretroFeatu
   return "";
 }
 
+namespace LIBRETRO
+{
+  struct LibretroFeature
+  {
+    const char *libretroId;
+    int featureIndex;
+  };
+
+  using LibretroFeatures = std::vector<LibretroFeature>;
+  using LibretroFeatureMap = std::map<libretro_device_t, LibretroFeatures>;
+
+  const LibretroFeatureMap featureMap = {
+    {
+      RETRO_DEVICE_JOYPAD, {
+        { "RETRO_DEVICE_ID_JOYPAD_A",       RETRO_DEVICE_ID_JOYPAD_A },
+        { "RETRO_DEVICE_ID_JOYPAD_B",       RETRO_DEVICE_ID_JOYPAD_B },
+        { "RETRO_DEVICE_ID_JOYPAD_X",       RETRO_DEVICE_ID_JOYPAD_X },
+        { "RETRO_DEVICE_ID_JOYPAD_Y",       RETRO_DEVICE_ID_JOYPAD_Y },
+        { "RETRO_DEVICE_ID_JOYPAD_START",   RETRO_DEVICE_ID_JOYPAD_START },
+        { "RETRO_DEVICE_ID_JOYPAD_SELECT",  RETRO_DEVICE_ID_JOYPAD_SELECT },
+        { "RETRO_DEVICE_ID_JOYPAD_UP",      RETRO_DEVICE_ID_JOYPAD_UP },
+        { "RETRO_DEVICE_ID_JOYPAD_DOWN",    RETRO_DEVICE_ID_JOYPAD_DOWN },
+        { "RETRO_DEVICE_ID_JOYPAD_RIGHT",   RETRO_DEVICE_ID_JOYPAD_RIGHT },
+        { "RETRO_DEVICE_ID_JOYPAD_LEFT",    RETRO_DEVICE_ID_JOYPAD_LEFT },
+        { "RETRO_DEVICE_ID_JOYPAD_L",       RETRO_DEVICE_ID_JOYPAD_L },
+        { "RETRO_DEVICE_ID_JOYPAD_R",       RETRO_DEVICE_ID_JOYPAD_R },
+        { "RETRO_DEVICE_ID_JOYPAD_L2",      RETRO_DEVICE_ID_JOYPAD_L2 },
+        { "RETRO_DEVICE_ID_JOYPAD_R2",      RETRO_DEVICE_ID_JOYPAD_R2 },
+        { "RETRO_DEVICE_ID_JOYPAD_L3",      RETRO_DEVICE_ID_JOYPAD_L3 },
+        { "RETRO_DEVICE_ID_JOYPAD_R3",      RETRO_DEVICE_ID_JOYPAD_R3 },
+      }
+    },
+    {
+      RETRO_DEVICE_ANALOG, {
+        { "RETRO_DEVICE_INDEX_ANALOG_LEFT",  RETRO_DEVICE_INDEX_ANALOG_LEFT },
+        { "RETRO_DEVICE_INDEX_ANALOG_RIGHT", RETRO_DEVICE_INDEX_ANALOG_RIGHT },
+      }
+    },
+    {
+      RETRO_DEVICE_MOUSE, {
+        { "RETRO_DEVICE_MOUSE",                     0 }, // Only 1 relative pointer, use ID 0
+        { "RETRO_DEVICE_ID_MOUSE_LEFT",             RETRO_DEVICE_ID_MOUSE_LEFT },
+        { "RETRO_DEVICE_ID_MOUSE_RIGHT",            RETRO_DEVICE_ID_MOUSE_RIGHT },
+        { "RETRO_DEVICE_ID_MOUSE_WHEELUP",          RETRO_DEVICE_ID_MOUSE_WHEELUP },
+        { "RETRO_DEVICE_ID_MOUSE_WHEELDOWN",        RETRO_DEVICE_ID_MOUSE_WHEELDOWN },
+        { "RETRO_DEVICE_ID_MOUSE_MIDDLE",           RETRO_DEVICE_ID_MOUSE_MIDDLE },
+        { "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP",    RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP },
+        { "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN",  RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN },
+      }
+    },
+    {
+      RETRO_DEVICE_LIGHTGUN, {
+        { "RETRO_DEVICE_LIGHTGUN",                  0 }, // Only 1 relative pointer, use ID 0
+        { "RETRO_DEVICE_ID_LIGHTGUN_TRIGGER",       RETRO_DEVICE_ID_LIGHTGUN_TRIGGER },
+        { "RETRO_DEVICE_ID_LIGHTGUN_CURSOR",        RETRO_DEVICE_ID_LIGHTGUN_CURSOR },
+        { "RETRO_DEVICE_ID_LIGHTGUN_TURBO",         RETRO_DEVICE_ID_LIGHTGUN_TURBO },
+        { "RETRO_DEVICE_ID_LIGHTGUN_PAUSE",         RETRO_DEVICE_ID_LIGHTGUN_PAUSE },
+        { "RETRO_DEVICE_ID_LIGHTGUN_START",         RETRO_DEVICE_ID_LIGHTGUN_START },
+        { "RETRO_DEVICE_ID_LIGHTGUN_AUX_A",         RETRO_DEVICE_ID_LIGHTGUN_AUX_A },
+        { "RETRO_DEVICE_ID_LIGHTGUN_AUX_B",         RETRO_DEVICE_ID_LIGHTGUN_AUX_B },
+        { "RETRO_DEVICE_ID_LIGHTGUN_SELECT",        RETRO_DEVICE_ID_LIGHTGUN_SELECT },
+        { "RETRO_DEVICE_ID_LIGHTGUN_AUX_C",         RETRO_DEVICE_ID_LIGHTGUN_AUX_C },
+        { "RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP",       RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP },
+        { "RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN",     RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN },
+        { "RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT",     RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT },
+        { "RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT",    RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT },
+        { "RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN",  RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN },
+        { "RETRO_DEVICE_ID_LIGHTGUN_RELOAD",        RETRO_DEVICE_ID_LIGHTGUN_RELOAD },
+      }
+    }
+  };
+}
+
 int LibretroTranslator::GetFeatureIndexV2(const std::string& strLibretroFeature)
 {
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_A")              return RETRO_DEVICE_ID_JOYPAD_A;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_B")              return RETRO_DEVICE_ID_JOYPAD_B;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_X")              return RETRO_DEVICE_ID_JOYPAD_X;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_Y")              return RETRO_DEVICE_ID_JOYPAD_Y;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_START")          return RETRO_DEVICE_ID_JOYPAD_START;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_SELECT")         return RETRO_DEVICE_ID_JOYPAD_SELECT;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_UP")             return RETRO_DEVICE_ID_JOYPAD_UP;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_DOWN")           return RETRO_DEVICE_ID_JOYPAD_DOWN;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_RIGHT")          return RETRO_DEVICE_ID_JOYPAD_RIGHT;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_LEFT")           return RETRO_DEVICE_ID_JOYPAD_LEFT;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L")              return RETRO_DEVICE_ID_JOYPAD_L;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R")              return RETRO_DEVICE_ID_JOYPAD_R;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L2")             return RETRO_DEVICE_ID_JOYPAD_L2;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R2")             return RETRO_DEVICE_ID_JOYPAD_R2;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_L3")             return RETRO_DEVICE_ID_JOYPAD_L3;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_JOYPAD_R3")             return RETRO_DEVICE_ID_JOYPAD_R3;
-  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_LEFT")        return RETRO_DEVICE_INDEX_ANALOG_LEFT;
-  if (strLibretroFeature == "RETRO_DEVICE_INDEX_ANALOG_RIGHT")       return RETRO_DEVICE_INDEX_ANALOG_RIGHT;
-  if (strLibretroFeature == "RETRO_DEVICE_MOUSE")                    return 0; // Only 1 relative pointer
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_LEFT")            return RETRO_DEVICE_ID_MOUSE_LEFT;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_RIGHT")           return RETRO_DEVICE_ID_MOUSE_RIGHT;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_WHEELUP")         return RETRO_DEVICE_ID_MOUSE_WHEELUP;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_WHEELDOWN")       return RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_MIDDLE")          return RETRO_DEVICE_ID_MOUSE_MIDDLE;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP")   return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
-  if (strLibretroFeature == "RETRO_DEVICE_LIGHTGUN")                 return 0; // Only 1 relative pointer
-  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_TRIGGER")      return RETRO_DEVICE_ID_LIGHTGUN_TRIGGER;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_CURSOR")       return RETRO_DEVICE_ID_LIGHTGUN_CURSOR;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_TURBO")        return RETRO_DEVICE_ID_LIGHTGUN_TURBO;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_PAUSE")        return RETRO_DEVICE_ID_LIGHTGUN_PAUSE;
-  if (strLibretroFeature == "RETRO_DEVICE_ID_LIGHTGUN_START")        return RETRO_DEVICE_ID_LIGHTGUN_START;
-  if (strLibretroFeature == "RETRO_RUMBLE_STRONG")                   return RETRO_RUMBLE_STRONG;
-  if (strLibretroFeature == "RETRO_RUMBLE_WEAK")                     return RETRO_RUMBLE_WEAK;
+  for (const auto &it : featureMap)
+  {
+    const auto &features = it.second;
+
+    auto it2 = std::find_if(features.begin(), features.end(),
+      [&strLibretroFeature](const LibretroFeature& feature)
+      {
+        return strLibretroFeature == feature.libretroId;
+      });
+
+    if (it2 != features.end())
+      return it2->featureIndex;
+  }
 
   return -1;
+}
+
+libretro_device_t LibretroTranslator::GetLibretroDevice(const std::string& strLibretroFeature)
+{
+  for (const auto &it : featureMap)
+  {
+    const libretro_device_t deviceType = it.first;
+    const auto &features = it.second;
+
+    auto it2 = std::find_if(features.begin(), features.end(),
+      [&strLibretroFeature](const LibretroFeature& feature)
+      {
+        return strLibretroFeature == feature.libretroId;
+      });
+
+    if (it2 != features.end())
+      return deviceType;
+  }
+
+  return RETRO_DEVICE_NONE;
 }
 
 const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned int index, unsigned int id)
@@ -288,6 +362,20 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
   }
 
   return "";
+}
+
+int LibretroTranslator::GetAxisID(const std::string& axisId)
+{
+  if (axisId == "RETRO_DEVICE_ID_ANALOG_X")         return RETRO_DEVICE_ID_ANALOG_X;
+  else if (axisId == "RETRO_DEVICE_ID_ANALOG_Y")    return RETRO_DEVICE_ID_ANALOG_Y;
+  else if (axisId == "RETRO_DEVICE_ID_MOUSE_X")     return RETRO_DEVICE_ID_MOUSE_X;
+  else if (axisId == "RETRO_DEVICE_ID_MOUSE_Y")     return RETRO_DEVICE_ID_MOUSE_Y;
+  else if (axisId == "RETRO_DEVICE_ID_LIGHTGUN_X")  return RETRO_DEVICE_ID_LIGHTGUN_X;
+  else if (axisId == "RETRO_DEVICE_ID_LIGHTGUN_Y")  return RETRO_DEVICE_ID_LIGHTGUN_Y;
+  else if (axisId == "RETRO_DEVICE_ID_POINTER_X")   return RETRO_DEVICE_ID_POINTER_X;
+  else if (axisId == "RETRO_DEVICE_ID_POINTER_Y")   return RETRO_DEVICE_ID_POINTER_Y;
+
+  return -1;
 }
 
 const char* LibretroTranslator::GetComponentName(libretro_device_t type, unsigned int index, unsigned int id)

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -104,6 +104,13 @@ namespace LIBRETRO
     static int GetFeatureIndexV2(const std::string& strLibretroFeature);
 
     /*!
+     * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.
+     * \param strFeatureName The feature name to translate.
+     * \return Translated button/feature id.
+     */
+    static libretro_device_t GetLibretroDevice(const std::string& strLibretroFeature);
+
+    /*!
      * \brief Translate identifiers to feature name (libretro buttonmap "mapto" field).
      * \param type The libretro device type
      * \param index The libretro index
@@ -120,6 +127,13 @@ namespace LIBRETRO
      * \return Translated name of a feature's component
      */
     static const char* GetComponentName(libretro_device_t type, unsigned int index, unsigned int id);
+
+    /*!
+     * \brief Translate libretro axis ID (libretro buttonmap "axis" field) to axis ID value in libretro.h
+     * \param axisId The axis ID
+     * \return Translated value of the axis ID
+     */
+    static int GetAxisID(const std::string& axisId);
 
     /*!
      * \brief Translate rumble motor name (libretro) to string representation (e.g. for logging).


### PR DESCRIPTION
This PR allows axis features, such as wheels and throttles, to be mapped in `buttonmap.xml`. An example of both are added in https://github.com/kodi-game/game.libretro.beetle-saturn/pull/4.

Axis features are mapped similar to other features in `buttonmap.xml`, but because they only map to a single axis of another feature (such as an analog stick or pointer), they must specify which axis they're mapped to.

Examples:

#### game.controller.saturn.arcade.racer

```xml
<feature name="wheel" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT" axis="RETRO_DEVICE_ID_ANALOG_X"/>
```

#### game.controller.saturn.mission.stick

```xml
<feature name="throttle" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" axis="RETRO_DEVICE_ID_ANALOG_Y"/>
```

For https://github.com/xbmc/xbmc/pull/13189.