### PR TITLE
Device subclass support

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -441,7 +441,7 @@ void UpdatePort(int port, bool connected, const game_controller* controller)
 
   if (port >= GAME_INPUT_PORT_JOYSTICK_START)
   {
-    const unsigned int device = CInputManager::Get().GetDevice(port);
+    const unsigned int device = CInputManager::Get().GetDeviceType(port);
 
     if (CLIENT)
       CLIENT->retro_set_controller_port_device(port, device);

--- a/src/input/ButtonMapper.cpp
+++ b/src/input/ButtonMapper.cpp
@@ -98,6 +98,22 @@ libretro_device_t CButtonMapper::GetLibretroType(const std::string& strControlle
   return deviceType;
 }
 
+libretro_subclass_t CButtonMapper::GetSubclass(const std::string& strControllerId)
+{
+  libretro_subclass_t subclass = 0;
+
+  for (auto& device : m_devices)
+  {
+    if (device->ControllerID() == strControllerId)
+    {
+      subclass = device->Subclass();
+      break;
+    }
+  }
+
+  return subclass;
+}
+
 int CButtonMapper::GetLibretroIndex(const std::string& strControllerId, const std::string& strFeatureName)
 {
   if (!strControllerId.empty() && !strFeatureName.empty())

--- a/src/input/ButtonMapper.h
+++ b/src/input/ButtonMapper.h
@@ -40,6 +40,8 @@ namespace LIBRETRO
 
     libretro_device_t GetLibretroType(const std::string& strControllerId);
 
+    libretro_subclass_t GetSubclass(const std::string& strControllerId);
+
     int GetLibretroIndex(const std::string& strControllerId, const std::string& strFeatureName);
     libretro_device_t GetLibretroDevice(const std::string& strControllerId, const std::string& strFeatureName) const;
     int GetAxisID(const std::string& strControllerId, const std::string& strFeatureName) const;

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -20,15 +20,12 @@
 #pragma once
 
 #define BUTTONMAP_XML_ROOT                  "buttonmap"
-
 #define BUTTONMAP_XML_ELM_CONTROLLER        "controller"
 #define BUTTONMAP_XML_ELM_FEATURE           "feature"
-
 #define BUTTONMAP_XML_ATTR_VERSION          "version"
-
 #define BUTTONMAP_XML_ATTR_CONTROLLER_ID    "id"
 #define BUTTONMAP_XML_ATTR_CONTROLLER_TYPE  "type"
-
+#define BUTTONMAP_XML_ATTR_CONTROLLER_SUBCLASS  "subclass"
 #define BUTTONMAP_XML_ATTR_FEATURE_NAME     "name"
 #define BUTTONMAP_XML_ATTR_FEATURE_MAPTO    "mapto"
 #define BUTTONMAP_XML_ATTR_FEATURE_AXIS     "axis"

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -59,7 +59,7 @@ namespace LIBRETRO
      * \brief Get the libretro device abstraction for the device connected to
      *        the specified port
      */
-    libretro_device_t GetDevice(unsigned int port);
+    libretro_device_t GetDeviceType(unsigned int port) const;
 
     bool OpenPort(unsigned int port);
     DevicePtr GetPort(unsigned int port);

--- a/src/input/LibretroDevice.cpp
+++ b/src/input/LibretroDevice.cpp
@@ -28,6 +28,8 @@
 
 #include "tinyxml.h"
 
+#include <sstream>
+
 using namespace LIBRETRO;
 
 CLibretroDevice::CLibretroDevice(const game_controller* controller)
@@ -38,6 +40,7 @@ CLibretroDevice::CLibretroDevice(const game_controller* controller)
   {
     m_controllerId = controller->controller_id;
     m_type = CButtonMapper::Get().GetLibretroType(m_controllerId);
+    m_subclass = CButtonMapper::Get().GetSubclass(m_controllerId);
   }
 }
 
@@ -50,6 +53,7 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
   if (!pElement)
     return false;
 
+  // Controller ID
   const char* controllerId = pElement->Attribute(BUTTONMAP_XML_ATTR_CONTROLLER_ID);
   if (!controllerId)
   {
@@ -57,6 +61,7 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
     return false;
   }
 
+  // Device type
   const char* type = pElement->Attribute(BUTTONMAP_XML_ATTR_CONTROLLER_TYPE);
   if (!type)
   {
@@ -77,6 +82,14 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
     return false;
   }
 
+  // Device subclass
+  const char* subclass = pElement->Attribute(BUTTONMAP_XML_ATTR_CONTROLLER_SUBCLASS);
+  if (subclass)
+    std::istringstream(subclass) >> m_subclass;
+  else
+    m_subclass = RETRO_SUBCLASS_NONE;
+
+  // Features
   const TiXmlElement* pFeature = pElement->FirstChildElement(BUTTONMAP_XML_ELM_FEATURE);
   if (!pFeature)
   {

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -28,11 +28,15 @@
 
 class TiXmlElement;
 
+// No subclass
+#define RETRO_SUBCLASS_NONE  (-1)
+
 namespace LIBRETRO
 {
   class CLibretroDevice;
   typedef std::shared_ptr<CLibretroDevice>   DevicePtr;
   typedef unsigned int                       libretro_device_t;
+  using libretro_subclass_t = int;
 
   struct FeatureMapItem
   {
@@ -52,6 +56,7 @@ namespace LIBRETRO
 
     std::string ControllerID(void) const { return m_controllerId; }
     libretro_device_t Type(void) const { return m_type; }
+    libretro_subclass_t Subclass() const { return m_subclass; }
     const FeatureMap& Features(void) const { return m_featureMap; }
     CLibretroDeviceInput& Input() { return *m_input; }
 
@@ -60,6 +65,7 @@ namespace LIBRETRO
   private:
     std::string                            m_controllerId;
     libretro_device_t                      m_type;
+    libretro_subclass_t                    m_subclass = RETRO_SUBCLASS_NONE;
     FeatureMap                             m_featureMap;
     std::unique_ptr<CLibretroDeviceInput>  m_input;
   };


### PR DESCRIPTION
The libretro API added subclass support a while ago. For example, see [Beetle Saturn's subclasses](https://github.com/libretro/beetle-saturn-libretro/blob/a0a6dad/input.cpp#L61-L69):

```c++
#define RETRO_DEVICE_SS_PAD        RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_JOYPAD, 0 )
#define RETRO_DEVICE_SS_3D_PAD     RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 0 )
#define RETRO_DEVICE_SS_WHEEL      RETRO_DEVICE_SUBCLASS( RETRO_DEVICE_ANALOG, 1 )
...
```

The XML for this looks like this (from [buttonmap.xml](https://github.com/kodi-game/game.libretro.beetle-saturn/blob/c640c23/game.libretro.beetle-saturn/resources/buttonmap.xml)):

```xml
<buttonmap version="2">
	<controller id="game.controller.saturn" type="RETRO_DEVICE_JOYPAD" subclass="0">
		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
		<feature name="c" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
		<feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
		<feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
		<feature name="z" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
		<feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
		<feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
		<feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
		<feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
		<feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
		<feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
		<feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
	</controller>
	<controller id="game.controller.saturn.3d" type="RETRO_DEVICE_ANALOG" subclass="0">
		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
		<feature name="c" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
		<feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
		<feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
		<feature name="z" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
		<feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
		<feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
		<feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
		<feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
		<feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
		<feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
		<feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
		<feature name="analogstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
	</controller>
	<controller id="game.controller.saturn.arcade.racer" type="RETRO_DEVICE_ANALOG" subclass="1">
		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
		<feature name="c" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
		<feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
		<feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
		<feature name="z" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
		<feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
		<feature name="wheel" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT" axis="RETRO_DEVICE_ID_ANALOG_X"/>
		<feature name="leftshift" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
		<feature name="rightshift" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
	</controller>
</buttonmap>
```

Subclasses are the analog of controller models added in https://github.com/xbmc/xbmc/pull/12608. However, controller models only allow specialization of metadata and topology; the feature layout is shared between models. Subclasses, on the other hand, have their own feature mapping, as you can see from the XML above.

Because subclasses do not depend on controller models (only controller profiles), model support has been deferred until https://github.com/kodi-game/game.libretro/pull/25.