### PR TITLE
Controller model support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/input/DefaultControllerTranslator.h
                      src/input/InputDefinitions.h
                      src/input/InputManager.h
+                     src/input/InputTypes.h
                      src/input/LibretroDevice.h
                      src/input/LibretroDeviceInput.h
                      src/libretro/ClientBridge.h

--- a/game.libretro/addon.xml.in
+++ b/game.libretro/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.libretro"
        name="Libretro Compatibility"
-       version="1.0.33"
+       version="1.0.34"
        provider-name="Team-Kodi">
   <backwards-compatibility abi="1.0.0"/>
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/input/ButtonMapper.h
+++ b/src/input/ButtonMapper.h
@@ -19,8 +19,10 @@
  */
 #pragma once
 
-#include "LibretroDevice.h" // for libretro_device_t
+#include "InputTypes.h"
 
+#include <memory>
+#include <vector>
 #include <string>
 
 // TODO: Make this class generic and move XML-specific stuff to xml subfolder
@@ -40,7 +42,8 @@ namespace LIBRETRO
 
     libretro_device_t GetLibretroType(const std::string& strControllerId);
 
-    libretro_subclass_t GetSubclass(const std::string& strControllerId);
+    const ModelInfo &GetDefaultModel(const std::string& strControllerId) const;
+    const ModelMap &GetModels(const std::string& strControllerId) const;
 
     int GetLibretroIndex(const std::string& strControllerId, const std::string& strFeatureName);
     libretro_device_t GetLibretroDevice(const std::string& strControllerId, const std::string& strFeatureName) const;
@@ -55,7 +58,13 @@ namespace LIBRETRO
 
     bool Deserialize(TiXmlElement* pElement);
 
+    using DeviceVector = std::vector<DevicePtr>;
+    using DeviceIt = DeviceVector::const_iterator;
+
+    static DeviceIt GetDevice(const DeviceVector &devices,
+                              const std::string &controllerId);
+
     bool                   m_bLoadAttempted;
-    std::vector<DevicePtr> m_devices;
+    DeviceVector m_devices;
   };
 }

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -21,6 +21,8 @@
 
 #define BUTTONMAP_XML_ROOT                  "buttonmap"
 #define BUTTONMAP_XML_ELM_CONTROLLER        "controller"
+#define BUTTONMAP_XML_ELM_MODELS            "models"
+#define BUTTONMAP_XML_ELM_MODEL             "model"
 #define BUTTONMAP_XML_ELM_FEATURE           "feature"
 #define BUTTONMAP_XML_ATTR_VERSION          "version"
 #define BUTTONMAP_XML_ATTR_CONTROLLER_ID    "id"
@@ -29,3 +31,4 @@
 #define BUTTONMAP_XML_ATTR_FEATURE_NAME     "name"
 #define BUTTONMAP_XML_ATTR_FEATURE_MAPTO    "mapto"
 #define BUTTONMAP_XML_ATTR_FEATURE_AXIS     "axis"
+#define BUTTONMAP_XML_ATTR_MODEL_NAME       "name"

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -106,7 +106,13 @@ namespace LIBRETRO
     void HandlePress(const game_key_event& key);
     bool IsPressed(uint32_t character) const;
 
-    std::map<int, DevicePtr>          m_devices;
+    struct DeviceState
+    {
+      DevicePtr device;
+      std::string model;
+    };
+
+    std::map<int, DeviceState>        m_devices;
     std::vector<game_key_event>       m_pressedKeys;
     mutable P8PLATFORM::CMutex        m_keyMutex;
   };

--- a/src/input/InputTypes.h
+++ b/src/input/InputTypes.h
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+// No subclass
+#define RETRO_SUBCLASS_NONE  (-1)
+
+namespace LIBRETRO
+{
+  class CLibretroDevice;
+  using DevicePtr = std::shared_ptr<CLibretroDevice>;
+
+  using libretro_device_t = unsigned int;
+  using libretro_subclass_t = int;
+
+  struct FeatureMapItem
+  {
+    std::string feature;
+    std::string axis;
+  };
+  using FeatureMap = std::map<std::string, FeatureMapItem>;
+
+  struct ModelInfo
+  {
+    libretro_subclass_t subclass = RETRO_SUBCLASS_NONE;
+  };
+  typedef std::map<std::string, ModelInfo> ModelMap;
+}

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include "InputTypes.h"
+
 #include "kodi_game_types.h"
 
 #include <map>
@@ -28,24 +30,8 @@
 
 class TiXmlElement;
 
-// No subclass
-#define RETRO_SUBCLASS_NONE  (-1)
-
 namespace LIBRETRO
 {
-  class CLibretroDevice;
-  typedef std::shared_ptr<CLibretroDevice>   DevicePtr;
-  typedef unsigned int                       libretro_device_t;
-  using libretro_subclass_t = int;
-
-  struct FeatureMapItem
-  {
-    std::string feature;
-    std::string axis;
-  };
-
-  using FeatureMap = std::map<std::string, FeatureMapItem>;
-
   class CLibretroDeviceInput;
 
   class CLibretroDevice
@@ -54,19 +40,25 @@ namespace LIBRETRO
     CLibretroDevice(const game_controller* controller);
     ~CLibretroDevice();
 
-    std::string ControllerID(void) const { return m_controllerId; }
+    const std::string &ControllerID(void) const { return m_controllerId; }
+    bool HasModel(const std::string &model) const;
+    const ModelInfo &DefaultModel() const { return m_defaultModel; }
+    const ModelMap &Models() const { return m_modelMap; }
+    const ModelInfo &GetModel(const std::string &model) const;
     libretro_device_t Type(void) const { return m_type; }
-    libretro_subclass_t Subclass() const { return m_subclass; }
     const FeatureMap& Features(void) const { return m_featureMap; }
     CLibretroDeviceInput& Input() { return *m_input; }
 
     bool Deserialize(const TiXmlElement* pElement, unsigned int buttonMapVersion);
 
   private:
+    static bool DeserializeModel(const TiXmlElement* pElement, ModelInfo &modelInfo);
+
     std::string                            m_controllerId;
     libretro_device_t                      m_type;
-    libretro_subclass_t                    m_subclass = RETRO_SUBCLASS_NONE;
     FeatureMap                             m_featureMap;
     std::unique_ptr<CLibretroDeviceInput>  m_input;
+    ModelInfo                              m_defaultModel;
+    ModelMap                               m_modelMap;
   };
 }


### PR DESCRIPTION
This PR is associated with https://github.com/xbmc/xbmc/pull/13248.

Models are required for the Virtual Gun in the Beetle Saturn buttonmap added in https://github.com/kodi-game/game.libretro.beetle-saturn/pull/4.

## Buttonmap XML documentatiom

Most controller models specify a libretro device subclass, which looks like this:

```xml
<buttonmap version="2">
	<controller id="game.controller.saturn" type="RETRO_DEVICE_JOYPAD" subclass="0">
		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
		...
```
For the Virtua Gun, we need a different subclass per model:

```xml
<buttonmap version="2">
	<controller id="game.controller.saturn.virtua.gun" type="RETRO_DEVICE_LIGHTGUN">
		<models>
			<model name="japanese" subclass="0"/>
			<model name="us" subclass="1"/>
		</models>
		<feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
		...
```

If no models are specified, the controller layout is applied to all models. Otherwise, a specified model is required. In the example above, any model can be used with `game.controller.saturn`, but the `game.controller.saturn.virtua.gun` layout can only be used with the `japanese` and `us` models.

Requires https://github.com/kodi-game/game.libretro/pull/24 (also included in this PR until merged)