### PR TITLE
Remove support for buttonmap v1 schema

### DIFF
--- a/src/input/LibretroDevice.cpp
+++ b/src/input/LibretroDevice.cpp
@@ -70,11 +70,7 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
   }
 
   m_controllerId = controllerId;
-
-  if (buttonMapVersion == 1)
-    m_type = LibretroTranslator::GetDeviceTypeV1(type);
-  else
-    m_type = LibretroTranslator::GetDeviceTypeV2(type);
+  m_type = LibretroTranslator::GetDeviceType(type);
 
   if (m_type == RETRO_DEVICE_NONE)
   {
@@ -115,15 +111,10 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
 
     const char* axis = pFeature->Attribute(BUTTONMAP_XML_ATTR_FEATURE_AXIS);
 
-    FeatureMapItem libretroFeature;
-
-    if (buttonMapVersion == 1)
-      libretroFeature.feature = LibretroTranslator::GetFeatureV2(mapto);
-    else
-      libretroFeature.feature = mapto;
+    FeatureMapItem libretroFeature = { mapto };
 
     // Ensure feature is valid
-    if (LibretroTranslator::GetFeatureIndexV2(libretroFeature.feature) < 0)
+    if (LibretroTranslator::GetFeatureIndex(libretroFeature.feature) < 0)
     {
       esyslog("<%s> tag has invalid \"%s\" attribute: \"%s\"", BUTTONMAP_XML_ELM_FEATURE, BUTTONMAP_XML_ATTR_FEATURE_MAPTO, mapto);
       return false;

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -82,19 +82,7 @@ GAME_HW_CONTEXT_TYPE LibretroTranslator::GetHWContextType(retro_hw_context_type 
 
 // --- Input translation --------------------------------------------------
 
-libretro_device_t LibretroTranslator::GetDeviceTypeV1(const std::string& strType)
-{
-  if (strType == "joypad")   return RETRO_DEVICE_JOYPAD;
-  if (strType == "mouse")    return RETRO_DEVICE_MOUSE;
-  if (strType == "keyboard") return RETRO_DEVICE_KEYBOARD;
-  if (strType == "lightgun") return RETRO_DEVICE_LIGHTGUN;
-  if (strType == "analog")   return RETRO_DEVICE_ANALOG;
-  if (strType == "pointer")  return RETRO_DEVICE_POINTER;
-
-  return RETRO_DEVICE_NONE;
-}
-
-libretro_device_t LibretroTranslator::GetDeviceTypeV2(const std::string& strLibretroType)
+libretro_device_t LibretroTranslator::GetDeviceType(const std::string& strLibretroType)
 {
   if (strLibretroType == "RETRO_DEVICE_JOYPAD")   return RETRO_DEVICE_JOYPAD;
   if (strLibretroType == "RETRO_DEVICE_MOUSE")    return RETRO_DEVICE_MOUSE;
@@ -119,32 +107,6 @@ const char* LibretroTranslator::GetDeviceName(libretro_device_t type)
   default:
     break;
   }
-
-  return "";
-}
-
-std::string LibretroTranslator::GetFeatureV2(const std::string& strLibretroFeature)
-{
-  if (strLibretroFeature == "a")           return "RETRO_DEVICE_ID_JOYPAD_A";
-  if (strLibretroFeature == "b")           return "RETRO_DEVICE_ID_JOYPAD_B";
-  if (strLibretroFeature == "x")           return "RETRO_DEVICE_ID_JOYPAD_X";
-  if (strLibretroFeature == "y")           return "RETRO_DEVICE_ID_JOYPAD_Y";
-  if (strLibretroFeature == "start")       return "RETRO_DEVICE_ID_JOYPAD_START";
-  if (strLibretroFeature == "select")      return "RETRO_DEVICE_ID_JOYPAD_SELECT";
-  if (strLibretroFeature == "up")          return "RETRO_DEVICE_ID_JOYPAD_UP";
-  if (strLibretroFeature == "down")        return "RETRO_DEVICE_ID_JOYPAD_DOWN";
-  if (strLibretroFeature == "right")       return "RETRO_DEVICE_ID_JOYPAD_RIGHT";
-  if (strLibretroFeature == "left")        return "RETRO_DEVICE_ID_JOYPAD_LEFT";
-  if (strLibretroFeature == "l")           return "RETRO_DEVICE_ID_JOYPAD_L";
-  if (strLibretroFeature == "r")           return "RETRO_DEVICE_ID_JOYPAD_R";
-  if (strLibretroFeature == "l2")          return "RETRO_DEVICE_ID_JOYPAD_L2";
-  if (strLibretroFeature == "r2")          return "RETRO_DEVICE_ID_JOYPAD_R2";
-  if (strLibretroFeature == "l3")          return "RETRO_DEVICE_ID_JOYPAD_L3";
-  if (strLibretroFeature == "r3")          return "RETRO_DEVICE_ID_JOYPAD_R3";
-  if (strLibretroFeature == "leftstick")   return "RETRO_DEVICE_INDEX_ANALOG_LEFT";
-  if (strLibretroFeature == "rightstick")  return "RETRO_DEVICE_INDEX_ANALOG_RIGHT";
-  if (strLibretroFeature == "strong")      return "RETRO_RUMBLE_STRONG";
-  if (strLibretroFeature == "weak")        return "RETRO_RUMBLE_WEAK";
 
   return "";
 }
@@ -222,7 +184,7 @@ namespace LIBRETRO
   };
 }
 
-int LibretroTranslator::GetFeatureIndexV2(const std::string& strLibretroFeature)
+int LibretroTranslator::GetFeatureIndex(const std::string& strLibretroFeature)
 {
   for (const auto &it : featureMap)
   {

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -69,18 +69,11 @@ namespace LIBRETRO
     // --- Input translation --------------------------------------------------
 
     /*!
-     * \brief Translate device type (libretro buttonmap "type" field) from version 1
-     * \param strType The device type to translate from a buttonmap at version 1
-     * \return The translated device type
-     */
-    static libretro_device_t GetDeviceTypeV1(const std::string& strType);
-
-    /*!
      * \brief Translate device type (Game API to libretro).
      * \param strType The device type to translate.
      * \return Translated device values.
      */
-    static libretro_device_t GetDeviceTypeV2(const std::string& strLibretroType);
+    static libretro_device_t GetDeviceType(const std::string& strLibretroType);
 
     /*!
      * \brief Translate device type (libretro) to string representation (e.g. for logging).
@@ -90,18 +83,11 @@ namespace LIBRETRO
     static const char* GetDeviceName(libretro_device_t type);
 
     /*!
-     * \brief Translate button/feature name (libretro buttonmap "mapto" field) from version 1 to version 2
-     * \param strFeatureName The feature name to translate from a buttonmap at version 1.
-     * \return The feature name for the buttonmap at version 2+.
-     */
-    static std::string GetFeatureV2(const std::string& strLibretroFeature);
-
-    /*!
      * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.
      * \param strFeatureName The feature name to translate.
      * \return Translated button/feature id.
      */
-    static int GetFeatureIndexV2(const std::string& strLibretroFeature);
+    static int GetFeatureIndex(const std::string& strLibretroFeature);
 
     /*!
      * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.


### PR DESCRIPTION
As part of my process for adding buttonmap.xml and topology.xml to all 70 emulators, no more buttonmap v1 files will exist, so drop the backwards compatibility completely.

To see all updated buttonmaps, refer to the list of emulator PRs at the bottom of https://github.com/garbear/xbmc/issues/87.