### PR TITLE
Game API v1.0.35: Mouse mapping support

### DIFF
--- a/game.libretro/addon.xml.in
+++ b/game.libretro/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.libretro"
        name="Libretro Compatibility"
-       version="1.0.34"
+       version="1.0.35"
        provider-name="Team-Kodi">
   <backwards-compatibility abi="1.0.0"/>
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -447,6 +447,24 @@ bool EnableKeyboard(bool enable, const game_controller* controller)
   return bSuccess;
 }
 
+bool EnableMouse(bool enable, const game_controller* controller)
+{
+  bool bSuccess = false;
+
+  if (enable)
+  {
+    if (controller != nullptr)
+      bSuccess = CInputManager::Get().EnableMouse(*controller);
+  }
+  else
+  {
+    CInputManager::Get().DisableMouse();
+    bSuccess = true;
+  }
+
+  return bSuccess;
+}
+
 void UpdatePort(int port, bool connected, const game_controller* controller)
 {
   if (connected)

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -66,6 +66,20 @@ namespace LIBRETRO
     void DisableKeyboard();
 
     /*!
+     * \brief Enable mouse input
+     *
+     * \param controller The mouse's controller profile
+     *
+     * \return True if mouse input was enabled, false otherwise
+     */
+    bool EnableMouse(const game_controller &controller);
+
+    /*!
+     * \brief Disable the keyboard and free any resources it held
+     */
+    void DisableMouse();
+
+    /*!
      * \brief Called when a device has been connected to an open port
      */
     void DeviceConnected(int port, bool bConnected, const game_controller* connectedController);
@@ -120,6 +134,7 @@ namespace LIBRETRO
   private:
     std::map<int, DevicePtr>          m_devices;
     DevicePtr m_keyboard;
+    DevicePtr m_mouse;
     mutable P8PLATFORM::CMutex        m_keyMutex;
   };
 }


### PR DESCRIPTION
This PR allows mouse input to be mapped from a controller profile to libretro input. A sample buttonmap looks like:

```xml
<buttonmap version="2">
  <controller id="game.controller.mouse" type="RETRO_DEVICE_MOUSE">
    <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>
    <feature name="right" mapto="RETRO_DEVICE_ID_MOUSE_RIGHT"/>
    <feature name="middle" mapto="RETRO_DEVICE_ID_MOUSE_MIDDLE"/>
    <feature name="wheelup" mapto="RETRO_DEVICE_ID_MOUSE_WHEELUP"/>
    <feature name="wheeldown" mapto="RETRO_DEVICE_ID_MOUSE_WHEELDOWN"/>
    <feature name="horizwheelup" mapto="RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP"/>
    <feature name="horizwheeldown" mapto="RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN"/>
    <feature name="pointer" mapto="RETRO_DEVICE_MOUSE"/>
  </controller>
</buttonmap>
```

Corresponds to https://github.com/xbmc/xbmc/pull/13482