### PR TITLE
Fix error loading button maps with rumble motors

### DIFF
--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -154,6 +154,8 @@ namespace LIBRETRO
         { "RETRO_DEVICE_ID_JOYPAD_R2",      RETRO_DEVICE_ID_JOYPAD_R2 },
         { "RETRO_DEVICE_ID_JOYPAD_L3",      RETRO_DEVICE_ID_JOYPAD_L3 },
         { "RETRO_DEVICE_ID_JOYPAD_R3",      RETRO_DEVICE_ID_JOYPAD_R3 },
+        { "RETRO_RUMBLE_STRONG",            RETRO_RUMBLE_STRONG },
+        { "RETRO_RUMBLE_WEAK",              RETRO_RUMBLE_WEAK },
       }
     },
     {


### PR DESCRIPTION
Reported here: https://github.com/kodi-game/game.libretro.pcsx-rearmed/issues/9#issuecomment-368670234