### PR TITLE
Add the FrameTime callback

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -38,6 +38,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <ctime>
 
 using namespace ADDON;
 using namespace LIBRETRO;
@@ -64,6 +65,7 @@ namespace LIBRETRO
   CClientBridge*                CLIENT_BRIDGE = nullptr;
   std::vector<CGameInfoLoader*> GAME_INFO;
   bool                          SUPPORTS_VFS = false; // TODO
+  int64_t                       FRAME_TIME_LAST = 0;
 }
 
 extern "C"
@@ -360,6 +362,13 @@ GAME_ERROR RunFrame(void)
 {
   if (!CLIENT)
     return GAME_ERROR_FAILED;
+
+  // Trigger the frame time callback before running the core.
+  // TODO: Switch from ctime's clock() to Kodi's reported progress.
+  int64_t current = static_cast<int64_t>(clock());
+  int64_t delta = current - FRAME_TIME_LAST;
+  FRAME_TIME_LAST = current;
+  CLIENT_BRIDGE->FrameTime(delta);
 
   CLIENT->retro_run();
 

--- a/src/libretro/ClientBridge.cpp
+++ b/src/libretro/ClientBridge.cpp
@@ -35,7 +35,8 @@ CClientBridge::CClientBridge()
     m_retro_hw_context_reset(nullptr),
     m_retro_hw_context_destroy(nullptr),
     m_retro_audio_set_state_callback(nullptr),
-    m_retro_audio_callback(nullptr)
+    m_retro_audio_callback(nullptr),
+    m_retro_frame_time_callback(nullptr)
 {
 }
 
@@ -85,6 +86,16 @@ GAME_ERROR CClientBridge::AudioAvailable(void)
     return GAME_ERROR_FAILED;
 
   m_retro_audio_callback();
+
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CClientBridge::FrameTime(int64_t usec)
+{
+  if (!m_retro_frame_time_callback)
+    return GAME_ERROR_FAILED;
+
+  m_retro_frame_time_callback(usec);
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/libretro/ClientBridge.h
+++ b/src/libretro/ClientBridge.h
@@ -47,18 +47,21 @@ namespace LIBRETRO
     GAME_ERROR HwContextDestroy(void);
     GAME_ERROR AudioEnable(bool enabled);
     GAME_ERROR AudioAvailable(void);
+    GAME_ERROR FrameTime(int64_t);
 
     typedef void (*KeyboardEventCallback)(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers);
     typedef void (*HwContextResetCallback)(void);
     typedef void (*HwContextDestroyCallback)(void);
     typedef void (*AudioEnableCallback)(bool enabled);
     typedef void (*AudioAvailableCallback)(void);
+    typedef void (*FrameTimeCallback)(int64_t);
 
     void SetKeyboardEvent(KeyboardEventCallback callback)       { m_retro_keyboard_event = callback; }
     void SetHwContextReset(HwContextResetCallback callback)     { m_retro_hw_context_reset = callback; }
     void SetHwContextDestroy(HwContextDestroyCallback callback) { m_retro_hw_context_destroy = callback; }
     void SetAudioEnable(AudioEnableCallback callback)           { m_retro_audio_set_state_callback = callback; }
     void SetAudioAvailable(AudioAvailableCallback callback)     { m_retro_audio_callback = callback; }
+    void SetFrameTime(FrameTimeCallback callback)               { m_retro_frame_time_callback = callback; }
 
   private:
     // The bridge is accomplished by invoking the callback provided by libretro's
@@ -69,5 +72,6 @@ namespace LIBRETRO
     HwContextDestroyCallback m_retro_hw_context_destroy;
     AudioEnableCallback      m_retro_audio_set_state_callback;
     AudioAvailableCallback   m_retro_audio_callback;
+    FrameTimeCallback        m_retro_frame_time_callback;
   };
 } // namespace LIBRETRO

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -302,7 +302,8 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       const retro_frame_time_callback *typedData = reinterpret_cast<const retro_frame_time_callback*>(data);
       if (typedData)
       {
-        // Frame time callback not implemented
+        // Store callbacks from libretro client.
+        m_clientBridge->SetFrameTime(typedData->callback);
         return false;
       }
       break;


### PR DESCRIPTION
Attempt to add the frame_time callback, to let cores know how much time has passed between frames. This has not been tested yet, as I haven't gotten it to compile yet. Would love your help on getting it to work.

It should use Kodi's frame time delta rather than ctime. Also, is RunFrame the right place to call this?

There's an example of its use over at [sdlarch.c](https://github.com/heuripedes/sdlarch/blob/master/sdlarch.c#L774-L783). 