### PR TITLE
Fix off-by-one error

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -243,7 +243,7 @@ bool CInputManager::InputEvent(const game_input_event& event)
     {
       // Resize devices if necessary
       if (port >= m_controllers.size())
-        m_controllers.resize(port);
+        m_controllers.resize(port + 1);
 
       if (m_controllers[port])
         bHandled = m_controllers[port]->Input().InputEvent(event);


### PR DESCRIPTION
This fixes an off-by-one error if an input event arrives for a controller that is not connected. This shouldn't be happening, as input events should only arrive for controllers that are connected. Still, better to be defensive.