### PR TITLE
Game API v1.0.38: New stream abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/settings/Settings.cpp
                      src/settings/SettingsGenerator.cpp
                      src/utils/PathUtils.cpp
+                     src/video/VideoGeometry.cpp
                      src/video/VideoStream.cpp)
 
 set(LIBRETRO_HEADERS src/GameInfoLoader.h
@@ -77,6 +78,7 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/settings/Settings.h
                      src/settings/SettingsTypes.h
                      src/utils/PathUtils.h
+                     src/video/VideoGeometry.h
                      src/video/VideoStream.h)
 
 build_addon(${PROJECT_NAME} LIBRETRO DEPLIBS)

--- a/game.libretro/addon.xml.in
+++ b/game.libretro/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.libretro"
        name="Libretro Compatibility"
-       version="1.0.36"
+       version="1.0.38"
        provider-name="Team-Kodi">
   <backwards-compatibility abi="1.0.0"/>
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -360,6 +360,8 @@ GAME_ERROR RunFrame(void)
 
   CLIENT->retro_run();
 
+  CLibretroEnvironment::Get().OnFrameEnd();
+
   return GAME_ERROR_NO_ERROR;
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -307,6 +307,8 @@ GAME_ERROR UnloadGame(void)
   {
     CLIENT->retro_unload_game();
 
+    CLibretroEnvironment::Get().CloseStreams();
+
     error = GAME_ERROR_NO_ERROR;
   }
 
@@ -315,27 +317,22 @@ GAME_ERROR UnloadGame(void)
   return error;
 }
 
-GAME_ERROR GetGameInfo(game_system_av_info* info)
+GAME_ERROR GetGameTiming(game_system_timing* timing_info)
 {
   if (!CLIENT)
     return GAME_ERROR_FAILED;
 
-  if (info == nullptr)
+  if (timing_info == nullptr)
     return GAME_ERROR_INVALID_PARAMETERS;
 
   retro_system_av_info retro_info = { };
   CLIENT->retro_get_system_av_info(&retro_info);
 
-  info->geometry.base_width   = retro_info.geometry.base_width;
-  info->geometry.base_height  = retro_info.geometry.base_height;
-  info->geometry.max_width    = retro_info.geometry.max_width;
-  info->geometry.max_height   = retro_info.geometry.max_height;
-  info->geometry.aspect_ratio = retro_info.geometry.aspect_ratio;
-  info->timing.fps            = retro_info.timing.fps;
-  info->timing.sample_rate    = retro_info.timing.sample_rate;
+  timing_info->fps = retro_info.timing.fps;
+  timing_info->sample_rate = retro_info.timing.sample_rate;
 
   // Report info to CLibretroEnvironment
-  CLibretroEnvironment::Get().UpdateSystemInfo(*info);
+  CLibretroEnvironment::Get().UpdateVideoGeometry(retro_info.geometry);
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -70,11 +70,12 @@ void CFrontendBridge::VideoRefresh(const void* data, unsigned int width, unsigne
 {
   if (data == RETRO_HW_FRAME_BUFFER_VALID)
   {
-    //! @todo Submit hardware framebuffer for rendering
+    CLibretroEnvironment::Get().Video().RenderHwFrame();
   }
   else if (data == nullptr)
   {
     // Libretro is sending a frame dupe command
+    CLibretroEnvironment::Get().Video().DupeFrame();
   }
   else
   {
@@ -203,8 +204,7 @@ uintptr_t CFrontendBridge::HwGetCurrentFramebuffer(void)
   if (!CLibretroEnvironment::Get().GetFrontend())
     return 0;
 
-  //! @todo Get current framebuffer from frontend
-  return 0;
+  return CLibretroEnvironment::Get().Video().GetHwFramebuffer();
 }
 
 retro_proc_address_t CFrontendBridge::HwGetProcAddress(const char *sym)

--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -70,8 +70,7 @@ void CFrontendBridge::VideoRefresh(const void* data, unsigned int width, unsigne
 {
   if (data == RETRO_HW_FRAME_BUFFER_VALID)
   {
-    if (CLibretroEnvironment::Get().GetFrontend())
-      CLibretroEnvironment::Get().GetFrontend()->RenderFrame();
+    //! @todo Submit hardware framebuffer for rendering
   }
   else if (data == nullptr)
   {
@@ -204,7 +203,8 @@ uintptr_t CFrontendBridge::HwGetCurrentFramebuffer(void)
   if (!CLibretroEnvironment::Get().GetFrontend())
     return 0;
 
-  return CLibretroEnvironment::Get().GetFrontend()->HwGetCurrentFramebuffer();
+  //! @todo Get current framebuffer from frontend
+  return 0;
 }
 
 retro_proc_address_t CFrontendBridge::HwGetProcAddress(const char *sym)

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -26,10 +26,13 @@
 
 #include "kodi_game_types.h"
 
+#include <memory>
 #include <string>
 
 namespace ADDON { class CHelper_libXBMC_addon; }
 class CHelper_libKODI_game;
+
+struct retro_game_geometry;
 
 namespace LIBRETRO
 {
@@ -57,8 +60,9 @@ namespace LIBRETRO
     CVideoStream& Video(void) { return m_videoStream; }
     CAudioStream& Audio(void) { return m_audioStream; }
 
-    game_system_av_info GetSystemInfo(void) const { return m_systemInfo; }
-    void UpdateSystemInfo(game_system_av_info info) { m_systemInfo = info; }
+    void CloseStreams();
+
+    void UpdateVideoGeometry(const retro_game_geometry &geometry);
 
     /*!
      * Returns the pixel format set by the libretro core. Instead of forwarding
@@ -88,7 +92,6 @@ namespace LIBRETRO
     CVideoStream                  m_videoStream;
     CAudioStream                  m_audioStream;
 
-    game_system_av_info m_systemInfo;
     GAME_PIXEL_FORMAT   m_videoFormat;
     GAME_VIDEO_ROTATION m_videoRotation;
 

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -80,6 +80,11 @@ namespace LIBRETRO
 
     std::string GetResourcePath(const char* relPath);
 
+    /*!
+     * \brief Called after game has been run for a frame
+     */
+    void OnFrameEnd();
+
     bool EnvironmentCallback(unsigned cmd, void* data);
 
   private:

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -66,9 +66,9 @@ GAME_VIDEO_ROTATION LibretroTranslator::GetVideoRotation(unsigned int rotation)
   switch (rotation)
   {
   case 0: return GAME_VIDEO_ROTATION_0;
-  case 1: return GAME_VIDEO_ROTATION_90;
-  case 2: return GAME_VIDEO_ROTATION_180;
-  case 3: return GAME_VIDEO_ROTATION_270;
+  case 1: return GAME_VIDEO_ROTATION_90_CCW;
+  case 2: return GAME_VIDEO_ROTATION_180_CCW;
+  case 3: return GAME_VIDEO_ROTATION_270_CCW;
   default:
     break;
   }

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -48,6 +48,19 @@ GAME_PIXEL_FORMAT LibretroTranslator::GetVideoFormat(retro_pixel_format format)
   return GAME_PIXEL_FORMAT_UNKNOWN;
 }
 
+retro_pixel_format LibretroTranslator::GetLibretroVideoFormat(GAME_PIXEL_FORMAT format)
+{
+  switch (format)
+  {
+    case GAME_PIXEL_FORMAT_0RGB1555: return RETRO_PIXEL_FORMAT_0RGB1555;
+    case GAME_PIXEL_FORMAT_0RGB8888: return RETRO_PIXEL_FORMAT_XRGB8888;
+    case GAME_PIXEL_FORMAT_RGB565:   return RETRO_PIXEL_FORMAT_RGB565;
+    default:
+      break;
+  }
+  return RETRO_PIXEL_FORMAT_UNKNOWN;
+}
+
 const char *LibretroTranslator::VideoFormatToString(retro_pixel_format format)
 {
   switch (format)
@@ -85,6 +98,8 @@ GAME_HW_CONTEXT_TYPE LibretroTranslator::GetHWContextType(retro_hw_context_type 
     case RETRO_HW_CONTEXT_OPENGLES2:   return GAME_HW_CONTEXT_OPENGLES2;
     case RETRO_HW_CONTEXT_OPENGL_CORE: return GAME_HW_CONTEXT_OPENGL_CORE;
     case RETRO_HW_CONTEXT_OPENGLES3:   return GAME_HW_CONTEXT_OPENGLES3;
+    case RETRO_HW_CONTEXT_OPENGLES_VERSION: return GAME_HW_CONTEXT_OPENGLES_VERSION;
+    case RETRO_HW_CONTEXT_VULKAN:      return GAME_HW_CONTEXT_VULKAN;
     case RETRO_HW_CONTEXT_NONE:
     case RETRO_HW_CONTEXT_DUMMY:
     default:

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -50,6 +50,13 @@ namespace LIBRETRO
     static GAME_PIXEL_FORMAT GetVideoFormat(retro_pixel_format format);
 
     /*!
+     * \brief Translate video format (Game API to libretro).
+     * \param format The video format to translate.
+     * \return Translated video format.
+     */
+    static retro_pixel_format GetLibretroVideoFormat(GAME_PIXEL_FORMAT format);
+
+    /*!
      * \brief Translate video format (libretro to string suitable for logging)
      * \param format The video format to translate
      * \return String representation of video format

--- a/src/video/VideoGeometry.cpp
+++ b/src/video/VideoGeometry.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2016 Team Kodi
+ *      Copyright (C) 2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -17,32 +17,22 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
-#include "SingleFrameAudio.h"
+#include "VideoGeometry.h"
+#include "libretro/libretro.h"
 
-#include "kodi_game_types.h"
+using namespace LIBRETRO;
 
-class CHelper_libKODI_game;
-
-namespace LIBRETRO
+CVideoGeometry::CVideoGeometry(const retro_game_geometry &geometry)
 {
-  class CAudioStream
-  {
-  public:
-    CAudioStream();
+  UpdateVideoGeometry(geometry);
+}
 
-    void Initialize(CHelper_libKODI_game* frontend);
-    void Deinitialize();
-
-    void AddFrame_S16NE(int16_t left, int16_t right) { m_singleFrameAudio.AddFrame(left, right); }
-
-    void AddFrames_S16NE(const uint8_t* data, unsigned int size);
-
-  private:
-    CHelper_libKODI_game* m_frontend;
-    CSingleFrameAudio     m_singleFrameAudio;
-
-    void* m_stream = nullptr;
-  };
+void CVideoGeometry::UpdateVideoGeometry(const retro_game_geometry &geometry)
+{
+  m_nominalWidth = geometry.base_width;
+  m_nominalHeight = geometry.base_height;
+  m_maxWidth = geometry.max_width;
+  m_maxHeight = geometry.max_height;
+  m_aspectRatio = geometry.aspect_ratio;
 }

--- a/src/video/VideoGeometry.h
+++ b/src/video/VideoGeometry.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2016 Team Kodi
+ *      Copyright (C) 2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,35 +19,30 @@
  */
 #pragma once
 
-#include "kodi_game_types.h"
-
-#include <memory>
-
-class CHelper_libKODI_game;
+struct retro_game_geometry;
 
 namespace LIBRETRO
 {
-  class CVideoGeometry;
-
-  class CVideoStream
+  class CVideoGeometry
   {
   public:
-    CVideoStream();
+    CVideoGeometry() = default;
+    CVideoGeometry(CVideoGeometry&) = default;
+    CVideoGeometry(const retro_game_geometry &geometry);
 
-    void Initialize(CHelper_libKODI_game* frontend);
-    void Deinitialize();
+    void UpdateVideoGeometry(const retro_game_geometry &geometry);
 
-    void SetGeometry(const CVideoGeometry &geometry);
-
-    void AddFrame(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, GAME_PIXEL_FORMAT format, GAME_VIDEO_ROTATION rotation);
+    unsigned int NominalWidth() const { return m_nominalWidth; }
+    unsigned int NominalHeight() const { return m_nominalHeight; }
+    unsigned int MaxWidth() const { return m_maxWidth; }
+    unsigned int MaxHeight() const { return m_maxHeight; }
+    float AspectRatio() const { return m_aspectRatio; }
 
   private:
-    void CloseStream();
-
-    CHelper_libKODI_game* m_frontend;
-
-    std::unique_ptr<CVideoGeometry> m_geometry;
-    void *m_stream = nullptr;
-    GAME_PIXEL_FORMAT m_format = GAME_PIXEL_FORMAT_UNKNOWN; // Guard against libretro changing formats
+    unsigned int m_nominalWidth = 0;
+    unsigned int m_nominalHeight = 0;
+    unsigned int m_maxWidth = 0;
+    unsigned int m_maxHeight = 0;
+    float m_aspectRatio = 0.0f;
   };
 }

--- a/src/video/VideoStream.h
+++ b/src/video/VideoStream.h
@@ -39,15 +39,28 @@ namespace LIBRETRO
 
     void SetGeometry(const CVideoGeometry &geometry);
 
+    void EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties);
+
+    uintptr_t GetHwFramebuffer();
+    bool GetSwFramebuffer(unsigned int width, unsigned int height, GAME_PIXEL_FORMAT requestedFormat, game_stream_sw_framebuffer_buffer &framebuffer);
+
     void AddFrame(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, GAME_PIXEL_FORMAT format, GAME_VIDEO_ROTATION rotation);
+    void DupeFrame() { } // Not supported
+    void RenderHwFrame();
+
+    void OnFrameEnd();
 
   private:
     void CloseStream();
 
+    // Initialization parameters
     CHelper_libKODI_game* m_frontend;
 
-    std::unique_ptr<CVideoGeometry> m_geometry;
+    // Stream properties
     void *m_stream = nullptr;
+    std::unique_ptr<CVideoGeometry> m_geometry;
+    GAME_STREAM_TYPE m_streamType = GAME_STREAM_UNKNOWN;
     GAME_PIXEL_FORMAT m_format = GAME_PIXEL_FORMAT_UNKNOWN; // Guard against libretro changing formats
+    std::unique_ptr<game_stream_buffer> m_framebuffer;
   };
 }


### PR DESCRIPTION
This adds support for the new stream abstraction. The stream abstraction allows for both hardware rendering and zero-copy support, so a second commit implements these features. In the future, RetroPlayer will support these features also.

Requires https://github.com/xbmc/xbmc/pull/13976