### PR TITLE
Fix keyboard in games that poll for keys

### DIFF
--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -116,7 +116,7 @@ int16_t CFrontendBridge::InputState(unsigned int port, unsigned int device, unsi
   switch (device)
   {
   case RETRO_DEVICE_JOYPAD:
-  //case RETRO_DEVICE_KEYBOARD: // TODO
+  case RETRO_DEVICE_KEYBOARD:
     inputState = CInputManager::Get().ButtonState(device, port, id) ? 1 : 0;
     break;
 


### PR DESCRIPTION
The Controller Topology PR (https://github.com/kodi-game/game.libretro/pull/31) added the ability to poll for keyboard input, but this was never enabled in the frontend bridge. This PR fixes that.

Fixes keyboard input on:

* MAME
* PUEA
* Vice
* Cap32
* px68
* Atari 800
* Hatari