### PR TITLE
Fix segfault on several cores

### DIFF
--- a/src/GameInfoLoader.cpp
+++ b/src/GameInfoLoader.cpp
@@ -124,7 +124,11 @@ bool CGameInfoLoader::GetMemoryStruct(retro_game_info& info) const
 {
   if (!m_dataBuffer.empty())
   {
-    info.path = nullptr;
+    //! @todo path is null according to libretro API, but many cores expect
+    //        the frontend to set this. Do so to guard against
+    //        noncompliant cores.
+    info.path = m_path.c_str();
+
     info.data = m_dataBuffer.data();
     info.size = m_dataBuffer.size();
     info.meta = nullptr;


### PR DESCRIPTION
The path parameter is null according to the libretro API, but many cores expect the frontend to set this. We adopt this behavior to guard against noncompliant cores.

Noncompiant cores tend to use the path to set a base file name, so VFS protocols aren't an issue. However, compliant cores will see the path parameter set and attempt to load by path instead of by memory. This might be a problem when loading from VFS paths where we need to load from memory.

## How Has This Been Tested?
Tested on OSX with FCEUmm.

## Screenshots

FCEUmm no longer crashes:

<img width="1920" alt="fceumm" src="https://user-images.githubusercontent.com/531482/45600946-e660ec00-b9b9-11e8-914e-5f0e40e791ac.png">
