### PR TITLE
[Game API] Add libretro Frame Time Callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/settings/Settings.cpp
                      src/settings/SettingsGenerator.cpp
                      src/utils/PathUtils.cpp
+                     src/utils/Timer.cpp
                      src/video/VideoGeometry.cpp
                      src/video/VideoStream.cpp)
 
@@ -80,6 +81,7 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/settings/Settings.h
                      src/settings/SettingsTypes.h
                      src/utils/PathUtils.h
+                     src/utils/Timer.h
                      src/video/VideoGeometry.h
                      src/video/VideoStream.h)
 

--- a/src/libretro/ClientBridge.cpp
+++ b/src/libretro/ClientBridge.cpp
@@ -35,7 +35,8 @@ CClientBridge::CClientBridge()
     m_retro_hw_context_reset(nullptr),
     m_retro_hw_context_destroy(nullptr),
     m_retro_audio_set_state_callback(nullptr),
-    m_retro_audio_callback(nullptr)
+    m_retro_audio_callback(nullptr),
+    m_retro_frame_time_callback(nullptr)
 {
 }
 
@@ -85,6 +86,16 @@ GAME_ERROR CClientBridge::AudioAvailable(void)
     return GAME_ERROR_FAILED;
 
   m_retro_audio_callback();
+
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CClientBridge::FrameTime(int64_t usec)
+{
+  if (!m_retro_frame_time_callback)
+    return GAME_ERROR_FAILED;
+
+  m_retro_frame_time_callback(usec);
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/libretro/ClientBridge.h
+++ b/src/libretro/ClientBridge.h
@@ -47,18 +47,21 @@ namespace LIBRETRO
     GAME_ERROR HwContextDestroy(void);
     GAME_ERROR AudioEnable(bool enabled);
     GAME_ERROR AudioAvailable(void);
+    GAME_ERROR FrameTime(int64_t);
 
     typedef void (*KeyboardEventCallback)(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers);
     typedef void (*HwContextResetCallback)(void);
     typedef void (*HwContextDestroyCallback)(void);
     typedef void (*AudioEnableCallback)(bool enabled);
     typedef void (*AudioAvailableCallback)(void);
+    typedef void (*FrameTimeCallback)(int64_t);
 
     void SetKeyboardEvent(KeyboardEventCallback callback)       { m_retro_keyboard_event = callback; }
     void SetHwContextReset(HwContextResetCallback callback)     { m_retro_hw_context_reset = callback; }
     void SetHwContextDestroy(HwContextDestroyCallback callback) { m_retro_hw_context_destroy = callback; }
     void SetAudioEnable(AudioEnableCallback callback)           { m_retro_audio_set_state_callback = callback; }
     void SetAudioAvailable(AudioAvailableCallback callback)     { m_retro_audio_callback = callback; }
+    void SetFrameTime(FrameTimeCallback callback)               { m_retro_frame_time_callback = callback; }
 
   private:
     // The bridge is accomplished by invoking the callback provided by libretro's
@@ -69,5 +72,6 @@ namespace LIBRETRO
     HwContextDestroyCallback m_retro_hw_context_destroy;
     AudioEnableCallback      m_retro_audio_set_state_callback;
     AudioAvailableCallback   m_retro_audio_callback;
+    FrameTimeCallback        m_retro_frame_time_callback;
   };
 } // namespace LIBRETRO

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -319,7 +319,8 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       const retro_frame_time_callback *typedData = reinterpret_cast<const retro_frame_time_callback*>(data);
       if (typedData)
       {
-        // Frame time callback not implemented
+        // Store callbacks from libretro client.
+        m_clientBridge->SetFrameTime(typedData->callback);
         return false;
       }
       break;

--- a/src/utils/Timer.cpp
+++ b/src/utils/Timer.cpp
@@ -1,0 +1,29 @@
+/*
+ *      Copyright (C) 2014-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Timer.h"
+
+using namespace LIBRETRO;
+
+uint64_t Timer::microseconds()
+{
+  const auto currenttime = m_clock.now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::microseconds>(currenttime).count();
+}

--- a/src/utils/Timer.h
+++ b/src/utils/Timer.h
@@ -1,0 +1,41 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace LIBRETRO
+{
+  /*!
+   * \brief Utility to get the current time.
+   */
+  class Timer
+  {
+  public:
+    /*!
+     * \brief Returns current time in microseconds.
+     */
+    uint64_t microseconds();
+
+  private:
+    std::chrono::high_resolution_clock m_clock;
+  };
+}


### PR DESCRIPTION
Here's another attempt at moving over to Chrono. I've had issues compiling this on my Linux machine. I'll continue reading through the docs and see if I can come up with anything.

```
/* Notifies a libretro core of time spent since last invocation
 * of retro_run() in microseconds.
 *
 * It will be called right before retro_run() every frame.
 * The frontend can tamper with timing to support cases like
 * fast-forward, slow-motion and framestepping.
 *
 * In those scenarios the reference frame time value will be used. */
```