### PR TITLE
Fix compiler error on macOS

### DIFF
--- a/src/settings/LibretroSettings.cpp
+++ b/src/settings/LibretroSettings.cpp
@@ -94,12 +94,12 @@ void CLibretroSettings::SetAllSettings(const retro_variable* libretroVariables)
       {
         if (std::find(setting.Values().begin(), setting.Values().end(), valueBuf) != setting.Values().end())
         {
-          dsyslog("Setting %s has value \"%s\" in Kodi",  setting.Key().c_str(), valueBuf);
+          dsyslog("Setting %s has value \"%s\" in Kodi",  setting.Key().c_str(), valueBuf.c_str());
           setting.SetCurrentValue(valueBuf);
         }
         else
         {
-          esyslog("Setting %s: invalid value \"%s\" (values are: %s)", setting.Key().c_str(), valueBuf, variable->value);
+          esyslog("Setting %s: invalid value \"%s\" (values are: %s)", setting.Key().c_str(), valueBuf.c_str(), variable->value);
           bValid = false;
         }
       }


### PR DESCRIPTION
Error was:

`
error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic method; call will abort at runtime [-Wnon-pod-varargs]
`