### PR TITLE
Implementing support for Achievements in RetroPlayer

### DIFF
--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -30,6 +30,7 @@ public:
   void ResetRuntime();
   bool GenerateHashFromFile(char* hash, int consoleID, const char* filePath);
   bool GetGameIDUrl(char* url, size_t size, const char* hash);
+  void SetRetroAchievementsCredentials(const char* username, const char* token);
   bool GetPatchFileUrl(
       char* url, size_t size, const char* username, const char* token, unsigned gameID);
   bool PostRichPresenceUrl(char* url,
@@ -42,7 +43,13 @@ public:
                            const char* richPresence);
   void EnableRichPresence(const char* script);
   void EvaluateRichPresence(char* evaluation, size_t size);
+  void ActivateAchievement(unsigned cheevo_id, const char* memaddr);
+  bool AwardAchievement(
+      char* url, size_t size, unsigned cheevo_id, int hardcore, const char* game_hash);
+  void DeactivateTriggeredAchievement(unsigned cheevo_id);
+  void TestCheevoStatusPerFrame();
   unsigned int Peek(unsigned int address, unsigned int numBytes);
+  void GetCheevo_URL_ID(void (*Callback)(const char* achievement_url, unsigned cheevo_id));
 
 private:
   const uint8_t* FixupFind(unsigned address, CMemoryMap& mmap, int consolecheevos);
@@ -51,6 +58,9 @@ private:
   size_t Reduse(size_t addr, size_t mask);
 
   static unsigned int PeekInternal(unsigned address, unsigned num_bytes, void* ud);
+  static void RuntimeEventHandler(const rc_runtime_event_t* runtime_event);
+
+  void (*Callback)(const char* achievement_url, unsigned cheevo_id);
 
   rc_runtime_t m_runtime;
   std::unordered_map<unsigned, const uint8_t*> m_addressFixups;
@@ -59,5 +69,11 @@ private:
   rc_richpresence_t* m_richPresence = nullptr;
   std::string m_richPresenceScript;
   std::vector<char> m_richPresenceBuffer;
+
+  std::string m_hash;
+  std::string m_username;
+  std::string m_token;
+  char* m_url;
+  unsigned m_cheevo_id;
 };
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -279,6 +279,8 @@ GAME_ERROR CGameLibRetro::RunFrame()
 
   m_client.retro_run();
 
+  CCheevos::Get().TestCheevoStatusPerFrame();
+
   CLibretroEnvironment::Get().OnFrameEnd();
 
   return GAME_ERROR_NO_ERROR;
@@ -493,6 +495,12 @@ GAME_ERROR CGameLibRetro::RCGetPatchFileUrl(char* url,
   return GAME_ERROR_NO_ERROR;
 }
 
+GAME_ERROR CGameLibRetro::SetRetroAchievementsCredentials(const char* username, const char* token)
+{
+  CCheevos::Get().SetRetroAchievementsCredentials(username, token);
+  return GAME_ERROR_NO_ERROR;
+}
+
 GAME_ERROR CGameLibRetro::RCPostRichPresenceUrl(char* url,
                                                 size_t urlSize,
                                                 char* postData,
@@ -520,6 +528,20 @@ GAME_ERROR CGameLibRetro::GetRichPresenceEvaluation(char* evaluation, size_t siz
 {
   CCheevos::Get().EvaluateRichPresence(evaluation, size);
 
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const char* memaddr)
+{
+  CCheevos::Get().ActivateAchievement(cheevo_id, memaddr);
+
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CGameLibRetro::GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
+                                                            unsigned cheevo_id))
+{
+  CCheevos::Get().GetCheevo_URL_ID(Callback);
   return GAME_ERROR_NO_ERROR;
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -78,6 +78,7 @@ public:
                                const char* username,
                                const char* token,
                                unsigned gameID) override;
+  GAME_ERROR SetRetroAchievementsCredentials(const char* username, const char* token);
   GAME_ERROR RCPostRichPresenceUrl(char* url,
                                    size_t urlSize,
                                    char* postData,
@@ -88,7 +89,10 @@ public:
                                    const char* richPresence) override;
   GAME_ERROR EnableRichPresence(const char* script) override;
   GAME_ERROR GetRichPresenceEvaluation(char* evaluation, size_t size) override;
+  GAME_ERROR ActivateAchievement(unsigned cheevo_id, const char* memaddr) override;
   GAME_ERROR RCResetRuntime() override;
+  GAME_ERROR GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
+                                               unsigned cheevo_id)) override;
 
 private:
   GAME_ERROR AudioAvailable();


### PR DESCRIPTION
This PR implement support for Achievements in ReteroPlayer. This PR is based on #67 , for adding support of RCheevos.
This PR is used by [garbear-xbmc #126](https://github.com/garbear/xbmc/pull/126) for implementing Achievements. 