### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/Readme.md
+++ b/Readme.md
@@ -5,8 +5,8 @@ This add-on provides a wrapper that allows Libretro cores to be loaded as game a
 This add-on depends on the Game API, which was added in Kodi 18 (Leia).
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/kodi-game/_apis/build/status/kodi-game.game.libretro?branchName=Matrix)](https://dev.azure.com/teamkodi/kodi-game/_build/latest?definitionId=25&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-game/job/game.libretro/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro/branches/)
+[![Build Status](https://dev.azure.com/teamkodi/kodi-game/_apis/build/status/kodi-game.game.libretro?branchName=Nexus)](https://dev.azure.com/teamkodi/kodi-game/_build/latest?definitionId=25&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/kodi-game/job/game.libretro/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/game.libretro?svg=true)](https://ci.appveyor.com/project/kodi-game/game-libretro) -->
 
 ## Loading mechanism

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/game.libretro/addon.xml.in
+++ b/game.libretro/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.libretro"
        name="Libretro Compatibility"
-       version="2.2.0"
+       version="20.0.0"
        provider-name="Team Kodi">
   <backwards-compatibility abi="1.0.0"/>
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.