### PR TITLE
Multitap fixes

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -376,7 +376,7 @@ bool CGameLibRetro::ConnectController(bool connect, const std::string& port_addr
   if (connect)
     strController = controller_id;
 
-  const int port = CInputManager::Get().GetPortIndex(strPortAddress);
+  int port = CInputManager::Get().GetPortIndex(strPortAddress);
   if (port < 0)
   {
     esyslog("Failed to connect controller, invalid port address: %s", strPortAddress.c_str());
@@ -394,10 +394,23 @@ bool CGameLibRetro::ConnectController(bool connect, const std::string& port_addr
       CInputManager::Get().DisconnectController(strPortAddress);
     }
 
-    dsyslog("Setting port \"%s\" (libretro port %d) to controller \"%s\" (libretro device ID %u)",
-        strPortAddress.c_str(), port, strController.c_str(), device);
+    // Get connection port override if specified
+    int connectionPort = -1;
+    if (CInputManager::Get().GetConnectionPortIndex(strPortAddress, connectionPort))
+      port = connectionPort;
 
-    m_client.retro_set_controller_port_device(port, device);
+    if (port >= 0)
+    {
+      dsyslog("Setting port \"%s\" (libretro port %d) to controller \"%s\" (libretro device ID %u)",
+          strPortAddress.c_str(), port, strController.c_str(), device);
+
+      m_client.retro_set_controller_port_device(port, device);
+    }
+    else
+    {
+      dsyslog("Ignoring port \"%s\" with controller \"%s\" (libretro device ID %u)",
+          strPortAddress.c_str(), strController.c_str(), device);
+    }
 
     return true;
   }

--- a/src/input/ControllerTopology.cpp
+++ b/src/input/ControllerTopology.cpp
@@ -156,7 +156,7 @@ int CControllerTopology::GetPortIndex(const PortPtr &port, const std::string &po
     {
       const ControllerPtr& controller = GetActiveController(port);
       if (controller)
-        portIndex = GetPortIndex(controller, portAddress, playerCount);
+        portIndex = GetPortIndex(controller, remainingAddress, playerCount);
     }
   }
 
@@ -179,7 +179,7 @@ int CControllerTopology::GetPortIndex(const ControllerPtr &controller, const std
 
     for (const auto &port : ports)
     {
-      portIndex = GetPortIndex(port, portAddress, playerCount);
+      portIndex = GetPortIndex(port, remainingAddress, playerCount);
       if (portIndex >= 0)
         break;
     }
@@ -666,7 +666,7 @@ void CControllerTopology::SplitAddress(const std::string &address, std::string &
   else
   {
     // Skip leading / to extract node ID
-    nodeId = address.substr(1, pos);
+    nodeId = address.substr(1, pos - 1);
     remainingAddress = address.substr(pos);
   }
 }

--- a/src/input/ControllerTopology.cpp
+++ b/src/input/ControllerTopology.cpp
@@ -613,7 +613,10 @@ CControllerTopology::PortPtr CControllerTopology::DeserializePort(const TiXmlEle
     const char* strConnectionPort = pElement->Attribute(TOPOLOGY_XML_ATTR_CONNECTION_PORT);
     std::string connectionPort = strConnectionPort != nullptr ? strConnectionPort : "";
 
-    port.reset(new Port{ portType, portId, std::move(connectionPort) });
+    const char* strForceConnected = pElement->Attribute(TOPOLOGY_XML_ATTR_FORCE_CONNECTED);
+    bool forceConnected = (strForceConnected != nullptr && std::string(strForceConnected) == "true");
+
+    port.reset(new Port{ portType, portId, std::move(connectionPort), forceConnected });
 
     const TiXmlElement* pChild = pElement->FirstChildElement(TOPOLOGY_XML_ELEM_ACCEPTS);
     if (pChild == nullptr)
@@ -684,6 +687,7 @@ game_input_port *CControllerTopology::GetPorts(const std::vector<PortPtr> &portV
     {
       ports[i].type = portVec[i]->type;
       ports[i].port_id = portVec[i]->portId.c_str();
+      ports[i].force_connected = portVec[i]->forceConnected;
 
       unsigned int deviceCount = 0;
       ports[i].accepted_devices = GetControllers(portVec[i]->accepts, deviceCount);

--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -68,6 +68,7 @@ namespace LIBRETRO
       GAME_PORT_TYPE type;
       std::string portId;
       std::string connectionPort; // Empty if no connection port is specified in topology.xml
+      bool forceConnected = false;
       std::vector<ControllerPtr> accepts;
       std::string activeId; // Empty if disconnected
     };

--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -90,6 +90,8 @@ namespace LIBRETRO
 
     static PortPtr CreateDefaultPort(const std::string &acceptedController);
 
+    static const ControllerPtr& GetActiveController(const PortPtr& port);
+
     static void SplitAddress(const std::string &address, std::string &nodeId, std::string &remainingAddress);
 
     std::vector<PortPtr> m_ports;

--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -76,6 +76,9 @@ namespace LIBRETRO
       bool bProvidesInput;
     };
 
+    static unsigned int GetPlayerCount(const PortPtr& port);
+    static unsigned int GetPlayerCount(const ControllerPtr& controller);
+
     static int GetPortIndex(const PortPtr &port, const std::string &portAddress, unsigned int &playerCount);
     static int GetPortIndex(const ControllerPtr &controller, const std::string &portAddress, unsigned int &playerCount);
 

--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -36,6 +36,8 @@ namespace LIBRETRO
 
     int GetPortIndex(const std::string &address) const;
 
+    bool GetConnectionPortIndex(const std::string &address, int &connectionPortId) const;
+
     std::string GetAddress(unsigned int portIndex) const;
 
     bool SetDevice(GAME_PORT_TYPE portType, const std::string &controllerId);
@@ -65,6 +67,7 @@ namespace LIBRETRO
     {
       GAME_PORT_TYPE type;
       std::string portId;
+      std::string connectionPort; // Empty if no connection port is specified in topology.xml
       std::vector<ControllerPtr> accepts;
       std::string activeId; // Empty if disconnected
     };
@@ -81,6 +84,9 @@ namespace LIBRETRO
 
     static int GetPortIndex(const PortPtr &port, const std::string &portAddress, unsigned int &playerCount);
     static int GetPortIndex(const ControllerPtr &controller, const std::string &portAddress, unsigned int &playerCount);
+
+    static bool GetConnectionPortIndex(const PortPtr &port, const std::string &portAddress, int &connectionPort);
+    static bool GetConnectionPortIndex(const ControllerPtr &controller, const std::string &portAddress, int &connectionPort);
 
     static std::string GetAddress(const PortPtr &port, unsigned int portIndex, unsigned int &playerCount);
     static std::string GetAddress(const ControllerPtr &controller, unsigned int portIndex, unsigned int &playerCount);

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -27,6 +27,7 @@
 #define TOPOLOGY_XML_ATTR_PORT_TYPE         "type"
 #define TOPOLOGY_XML_ATTR_PORT_ID           "id"
 #define TOPOLOGY_XML_ATTR_CONNECTION_PORT   "connectionPort"
+#define TOPOLOGY_XML_ATTR_FORCE_CONNECTED   "forceConnected"
 #define TOPOLOGY_XML_ATTR_CONTROLLER_ID     "controller"
 
 // Game API strings

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -26,6 +26,7 @@
 #define TOPOLOGY_XML_ATTR_PLAYER_LIMIT      "playerlimit"
 #define TOPOLOGY_XML_ATTR_PORT_TYPE         "type"
 #define TOPOLOGY_XML_ATTR_PORT_ID           "id"
+#define TOPOLOGY_XML_ATTR_CONNECTION_PORT   "connectionPort"
 #define TOPOLOGY_XML_ATTR_CONTROLLER_ID     "controller"
 
 // Game API strings

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -167,6 +167,11 @@ int CInputManager::GetPortIndex(const std::string &address) const
   return CControllerTopology::GetInstance().GetPortIndex(address);
 }
 
+bool CInputManager::GetConnectionPortIndex(const std::string &address, int& connectionPort) const
+{
+  return CControllerTopology::GetInstance().GetConnectionPortIndex(address, connectionPort);
+}
+
 std::string CInputManager::GetAddress(unsigned int port) const
 {
   return CControllerTopology::GetInstance().GetAddress(port);

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -92,6 +92,18 @@ namespace LIBRETRO
      */
     int GetPortIndex(const std::string &address) const;
 
+    /*!
+     * \brief Get the port number that we should use when setting the
+     * controller port
+     *
+     * \param address The port address
+     * \param[out] connectionPort The port used to change connections, or
+     * untouched if this function returns false
+     *
+     * \return True if a connection port was specified, false otherwise
+     */
+    bool GetConnectionPortIndex(const std::string &address, int& connectionPort) const;
+
     std::string GetAddress(unsigned int port) const;
 
     /*!

--- a/src/input/LibretroDevice.cpp
+++ b/src/input/LibretroDevice.cpp
@@ -75,12 +75,6 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
 
   // Features
   const TiXmlElement* pFeature = pElement->FirstChildElement(BUTTONMAP_XML_ELM_FEATURE);
-  if (!pFeature)
-  {
-    esyslog("Can't find <%s> tag for controller \"%s\"", BUTTONMAP_XML_ELM_FEATURE, m_controllerId.c_str());
-    return false;
-  }
-
   while (pFeature)
   {
     const char* name = pFeature->Attribute(BUTTONMAP_XML_ATTR_FEATURE_NAME);


### PR DESCRIPTION
## Description

This PR joins https://github.com/xbmc/xbmc/pull/20408 to fix Multitaps and get them working in Kodi. It includes fixes, some refactoring, and two features required for Snes9x Multitaps.

Snes9x multitaps behave idiosyncratically, in a way particular to Snes9x cores. Polling for input works normally, where controllers are assigned depth-first to port IDs. For example, if two Multitaps are connected, port assignment traverses the topology depth-first and assigns ports 0-3 to the four controllers on the first multitap, and ports 4-7 to the four controllers on the second multitap.

However, connecting/disconnecting a controller uses a different port identification scheme. Port 0 is used to refer to the hardware port 0. Port 1 is used to refer to the hardware port 1. No other ports are allowed. This is incompatible with the depth-first polling, so a new strategy is needed to handle this idiosyncratic behavior.

To work around this, I added two new fields:

* Libretro port ID (note: looking for better name)
* Flag to allow controllers to disconnect

### Libretro port ID

Here is the topology.xml file we started with:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<logicaltopology>
  <port id="1">
    <accepts controller="game.controller.snes"/>
    <accepts controller="game.controller.snes.mouse"/>
    <accepts controller="game.controller.snes.multitap">
      <port id="1">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="2">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="3">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="4">
        <accepts controller="game.controller.snes"/>
      </port>
    </accepts>
  </port>
  <port id="2">
    <accepts controller="game.controller.snes"/>
    <accepts controller="game.controller.snes.mouse"/>
    <accepts controller="game.controller.snes.multitap">
      <port id="1">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="2">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="3">
        <accepts controller="game.controller.snes"/>
      </port>
      <port id="4">
        <accepts controller="game.controller.snes"/>
      </port>
    </accepts>
    <accepts controller="game.controller.snes.super.scope"/>
    <accepts controller="game.controller.konami.justifier.snes"/>
  </port>
</logicaltopology>
```

Here is the file with libretro port IDs:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<logicaltopology>
  <port type="controller" id="1" connectionPort="0">
    <accepts controller="game.controller.snes"/>
    <accepts controller="game.controller.snes.mouse"/>
    <accepts controller="game.controller.snes.multitap">
      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
    </accepts>
  </port>
  <port type="controller" id="2" connectionPort="1">
    <accepts controller="game.controller.snes"/>
    <accepts controller="game.controller.snes.mouse"/>
    <accepts controller="game.controller.snes.multitap">
      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.snes"/>
      </port>
    </accepts>
    <accepts controller="game.controller.snes.super.scope"/>
    <accepts controller="game.controller.konami.justifier.snes"/>
  </port>
</logicaltopology>
```

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/20408