### PR TITLE
Fix segfault when opening 3DEngine core

### DIFF
--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -218,7 +218,8 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
         hw_info.version_minor      = typedData->version_minor;
         hw_info.cache_context      = typedData->cache_context;
         hw_info.debug_context      = typedData->debug_context;
-        m_videoStream.EnableHardwareRendering(hw_info);
+        if (!m_videoStream.EnableHardwareRendering(hw_info))
+          return false;
 
         // Store callbacks from libretro client
         m_clientBridge->SetHwContextReset(typedData->context_reset);

--- a/src/video/VideoStream.cpp
+++ b/src/video/VideoStream.cpp
@@ -43,10 +43,10 @@ void CVideoStream::SetGeometry(const CVideoGeometry &geometry)
   *m_geometry = geometry;
 }
 
-void CVideoStream::EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties)
+bool CVideoStream::EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties)
 {
   if (m_addon == nullptr)
-    return;
+    return false;
 
   CloseStream();
 
@@ -55,8 +55,12 @@ void CVideoStream::EnableHardwareRendering(const game_stream_hw_framebuffer_prop
   streamProps.type = GAME_STREAM_HW_FRAMEBUFFER;
   streamProps.hw_framebuffer = properties;
 
-  m_stream.Open(streamProps);
+  if (!m_stream.Open(streamProps))
+    return false;
+
   m_streamType = GAME_STREAM_HW_FRAMEBUFFER;
+
+  return true;
 }
 
 uintptr_t CVideoStream::GetHwFramebuffer()

--- a/src/video/VideoStream.h
+++ b/src/video/VideoStream.h
@@ -28,7 +28,7 @@ namespace LIBRETRO
 
     void SetGeometry(const CVideoGeometry &geometry);
 
-    void EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties);
+    bool EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties);
 
     uintptr_t GetHwFramebuffer();
     bool GetSwFramebuffer(unsigned int width, unsigned int height, GAME_PIXEL_FORMAT requestedFormat, game_stream_sw_framebuffer_buffer &framebuffer);


### PR DESCRIPTION
## Description

The return value of OpenStream() wasn't checked. As a result, the core 3DEngine would successfully initialize even though GL support was missing, but then segfault in the run loop.

## How has this been tested?

After this change, the 3DEngine core exits with an error message instead of segfaulting.

![Screenshot from 2021-10-30 23-20-12](https://user-images.githubusercontent.com/531482/139570781-5e6d00f7-0f9a-4784-a1b4-62235ce7cf61.png)


