### PR TITLE
Add stubbed callback for LED state

### DIFF
--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -226,6 +226,15 @@ bool CFrontendBridge::RumbleSetState(unsigned int port, retro_rumble_effect effe
   return true;
 }
 
+void CFrontendBridge::LedSetState(int led, int state)
+{
+  if (!CLibretroEnvironment::Get().GetAddon())
+    return;
+
+  // TODO
+  kodi::Log(ADDON_LOG_DEBUG, "LED: %d, state: %d", led, state);
+}
+
 bool CFrontendBridge::SensorSetState(unsigned port, retro_sensor_action action, unsigned rate)
 {
   const bool bEnabled = (action == RETRO_SENSOR_ACCELEROMETER_ENABLE);

--- a/src/libretro/FrontendBridge.h
+++ b/src/libretro/FrontendBridge.h
@@ -44,6 +44,7 @@ namespace LIBRETRO
     static uintptr_t HwGetCurrentFramebuffer(void);
     static retro_proc_address_t HwGetProcAddress(const char *sym);
     static bool RumbleSetState(unsigned port, retro_rumble_effect effect, uint16_t strength);
+    static void LedSetState(int led, int state);
     static bool SensorSetState(unsigned port, retro_sensor_action action, unsigned rate);
     static float SensorGetInput(unsigned port, unsigned id);
     static bool StartCamera(void);

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -563,8 +563,8 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
     retro_led_interface* typedData = reinterpret_cast<retro_led_interface*>(data);
     if (typedData)
     {
-      // Not implemented
-      return false;
+      // Expose callback to libretro core
+      typedData->set_led_state = CFrontendBridge::LedSetState;
     }
     break;
   }


### PR DESCRIPTION
## Description

This PR introduces a stubbed callback to handle LED commands. It's not hooked up to anything other than the log, but P-UAE doesn't check the return value of the `RETRO_ENVIRONMENT_GET_LED_INTERFACE`  environment command, and crashes when it tries to use the invalid function pointer.

Needed to prevent P-UAE from segfaulting on the first frame.

## How has this been tested?

From kodi.log:

```
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 0, state: 1
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 0, state: 0
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 0, state: 1
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 2, state: 1
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 2, state: 0
DEBUG <general>: AddOnLog: game.libretro.uae: LED: 2, state: 1
```

With this patch, P-UAE successfully enters the game loop:

![Screenshot from 2021-11-10 17-25-31](https://user-images.githubusercontent.com/531482/141221243-d6a1856a-d8a4-405d-8ce6-a916458299be.png)

