### PR TITLE
Fix compiler warnings on Windows

### DIFF
--- a/src/GameInfoLoader.cpp
+++ b/src/GameInfoLoader.cpp
@@ -53,14 +53,14 @@ bool CGameInfoLoader::Load(void)
     return false;
   }
 
-  int64_t size = statStruct.GetSize();
+  uint64_t size = statStruct.GetSize();
   if (size > 0)
   {
     // Size is known, read entire file at once (unless it is too big)
     if (size <= MAX_READ_SIZE)
     {
-      m_dataBuffer.resize((size_t)size);
-      file.Read(m_dataBuffer.data(), size);
+      m_dataBuffer.resize(static_cast<size_t>(size));
+      file.Read(m_dataBuffer.data(), static_cast<size_t>(size));
     }
     else
     {
@@ -72,7 +72,7 @@ bool CGameInfoLoader::Load(void)
   else
   {
     // Read file in chunks
-    unsigned int bytesRead;
+    ssize_t bytesRead;
     uint8_t buffer[READ_SIZE];
     while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
     {

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -233,7 +233,7 @@ const uint8_t* CCheevos::PatchAddress(size_t address, CMemoryMap& mmap, int cons
         break;
     }
 
-    for (int i = 0; i < mmap.Size(); i++)
+    for (size_t i = 0; i < mmap.Size(); i++)
     {
       const retro_memory_descriptor_kodi& desc = mmap[i];
       if (((desc.descriptor.start ^ address) & desc.descriptor.select) == 0)

--- a/src/cheevos/CheevosFrontendBridge.cpp
+++ b/src/cheevos/CheevosFrontendBridge.cpp
@@ -54,7 +54,7 @@ size_t CCheevosFrontendBridge::GetPosition(void* file_handle)
     return 0;
 
   // Return the current read / write position for the file
-  return currentPosition;
+  return static_cast<size_t>(currentPosition);
 }
 
 void CCheevosFrontendBridge::Seek(void* file_handle, size_t offset, int origin)

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -129,7 +129,7 @@ libretro_device_t CInputManager::ConnectController(const std::string &address, c
         else
           deviceType = device->Type();
 
-        if (port >= m_controllers.size())
+        if (port >= static_cast<int>(m_controllers.size()))
           m_controllers.resize(port + 1);
 
         m_controllers[port] = std::move(device);
@@ -153,7 +153,7 @@ bool CInputManager::DisconnectController(const std::string &address)
   {
     CControllerTopology::GetInstance().RemoveController(address);
 
-    if (port < m_controllers.size())
+    if (port < static_cast<int>(m_controllers.size()))
       m_controllers[port].reset();
 
     bSuccess = true;
@@ -182,7 +182,7 @@ libretro_device_t CInputManager::GetDeviceType(const std::string &address) const
   libretro_device_t deviceType = RETRO_DEVICE_NONE;
 
   int port = GetPortIndex(address);
-  if (0 <= port && port < m_controllers.size())
+  if (0 <= port && port < static_cast<int>(m_controllers.size()))
   {
     const DevicePtr &device = m_controllers[port];
 
@@ -244,7 +244,7 @@ bool CInputManager::InputEvent(const game_input_event& event)
     if (0 <= port && port < PORT_MAX_COUNT)
     {
       // Resize devices if necessary
-      if (port >= m_controllers.size())
+      if (port >= static_cast<int>(m_controllers.size()))
         m_controllers.resize(port + 1);
 
       if (m_controllers[port])


### PR DESCRIPTION
## Description

As title says, this change fixes a compiler warning on Windows. The function Read() returns `ssize_t` (see binary add-on API).

Warnings were:

```
GameInfoLoader.cpp(63): warning C4244: 'argument': conversion from 'int64_t' to 'size_t', possible loss of data

GameInfoLoader.cpp(77): warning C4244: '=': conversion from 'ssize_t' to 'unsigned int', possible loss of data

Cheevos.cpp(236): warning C4018: '<': signed/unsigned mismatch

CheevosFrontendBridge.cpp(57): warning C4244: 'return': conversion from 'const int64_t' to 'size_t', possible loss of data

InputManager.cpp(132): warning C4018: '>=': signed/unsigned mismatch

InputManager.cpp(156): warning C4018: '<': signed/unsigned mismatch

InputManager.cpp(185): warning C4018: '<': signed/unsigned mismatch

InputManager.cpp(247): warning C4018: '>=': signed/unsigned mismatch
```

## How has this been tested?

Passes CI. Observed no more warnings in the log.