### PR TITLE
Fix paths to libretro.h

### DIFF
--- a/src/libretro/ClientBridge.cpp
+++ b/src/libretro/ClientBridge.cpp
@@ -6,7 +6,8 @@
  */
 
 #include "ClientBridge.h"
-#include "libretro.h"
+
+#include "libretro-common/libretro.h"
 
 // Causing errors with std::numeric_limits<int>::max()
 #ifdef max

--- a/src/libretro/FrontendBridge.h
+++ b/src/libretro/FrontendBridge.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "libretro.h"
+#include "libretro-common/libretro.h"
 
 #include <memory>
 #include <string>

--- a/src/libretro/LibretroDLL.h
+++ b/src/libretro/LibretroDLL.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "libretro.h"
+#include "libretro-common/libretro.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -8,7 +8,8 @@
 #pragma once
 
 #include "input/LibretroDevice.h"
-#include "libretro.h"
+
+#include "libretro-common/libretro.h"
 
 #include <kodi/addon-instance/Game.h>
 


### PR DESCRIPTION
## Description

As title says, this PR simply updates some paths missed in https://github.com/kodi-game/game.libretro/pull/84.

## How has this been tested?

Build succeeds (though not sure why it didn't fail before).