### PR TITLE
Fix azure pipeline by updating Windows image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,25 +16,25 @@ jobs:
   - job: Windows
 
     pool:
-      vmImage: 'VS2017-Win2016'
+      vmImage: 'windows-2022'
 
     strategy:
       matrix:
         Win32:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: Win32
           CONFIGURATION: Release
         Win64:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
         Win64-UWP:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
         ARM64-UWP:
-          GENERATOR: "Visual Studio 15 2017"
+          GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: ARM64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"


### PR DESCRIPTION
## Description

As title says, this updates the azure pipeline image to the recommended windows version.

According to https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation:

```
We understand this may impact your pipelines. If you are using vs2017-win2016 these are options to move forward:
– Start using the windows-2019 image. This image contains most of the tools (e.g. .NET Framework versions) currently available on vs2017-win2016.
```

This PR solves the problem by using the recommended image.

I chose 2022 and VS 2022 because that's what @AlwinEsch has been using for other add-ons.

## How has this been tested?

Azure CI succeeds.