### PR TITLE
Game API v6.0.0: Achievement support for RetroPlayer

### DIFF
--- a/game.libretro/addon.xml.in
+++ b/game.libretro/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.libretro"
        name="Libretro Compatibility"
-       version="20.2.2"
+       version="20.3.0"
        provider-name="Team Kodi">
   <backwards-compatibility abi="1.0.0"/>
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -30,6 +30,7 @@ public:
   void ResetRuntime();
   bool GenerateHashFromFile(std::string& hash, unsigned int consoleID, const std::string& filePath);
   bool GetGameIDUrl(std::string& url, const std::string& hash);
+  void SetRetroAchievementsCredentials(const std::string& username, const std::string& token);
   bool GetPatchFileUrl(std::string& url,
                        const std::string& username,
                        const std::string& token,
@@ -42,7 +43,13 @@ public:
                            const std::string& richPresence);
   void EnableRichPresence(const std::string& script);
   void EvaluateRichPresence(std::string& evaluation, unsigned int consoleID);
+  void ActivateAchievement(unsigned cheevo_id, const char* memaddr);
+  bool AwardAchievement(
+      char* url, size_t size, unsigned cheevo_id, int hardcore, const std::string& game_hash);
+  void DeactivateTriggeredAchievement(unsigned cheevo_id);
+  void TestCheevoStatusPerFrame();
   unsigned int Peek(unsigned int address, unsigned int numBytes);
+  void GetCheevo_URL_ID(void (*callback)(const char* achievement_url, unsigned cheevo_id));
 
 private:
   const uint8_t* FixupFind(unsigned address, CMemoryMap& mmap, int consolecheevos);
@@ -51,6 +58,9 @@ private:
   size_t Reduce(size_t addr, size_t mask);
 
   static unsigned int PeekInternal(unsigned address, unsigned num_bytes, void* ud);
+  static void RuntimeEventHandler(const rc_runtime_event_t* runtime_event);
+
+  void (*m_callback)(const char* achievement_url, unsigned cheevo_id);
 
   int m_consoleID;
 
@@ -61,5 +71,9 @@ private:
   rc_richpresence_t* m_richPresence = nullptr;
   std::string m_richPresenceScript;
   std::vector<char> m_richPresenceBuffer;
+
+  std::string m_hash;
+  std::string m_username;
+  std::string m_token;
 };
 } // namespace LIBRETRO

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -274,6 +274,8 @@ GAME_ERROR CGameLibRetro::RunFrame()
 
   m_client.retro_run();
 
+  CCheevos::Get().TestCheevoStatusPerFrame();
+
   CLibretroEnvironment::Get().OnFrameEnd();
 
   return GAME_ERROR_NO_ERROR;
@@ -502,6 +504,12 @@ GAME_ERROR CGameLibRetro::RCGetPatchFileUrl(std::string& url,
   return GAME_ERROR_NO_ERROR;
 }
 
+GAME_ERROR CGameLibRetro::SetRetroAchievementsCredentials(const char* username, const char* token)
+{
+  CCheevos::Get().SetRetroAchievementsCredentials(username, token);
+  return GAME_ERROR_NO_ERROR;
+}
+
 GAME_ERROR CGameLibRetro::RCPostRichPresenceUrl(std::string& url,
                                                 std::string& postData,
                                                 const std::string& username,
@@ -527,6 +535,20 @@ GAME_ERROR CGameLibRetro::RCGetRichPresenceEvaluation(std::string& evaluation,
 {
   CCheevos::Get().EvaluateRichPresence(evaluation, consoleID);
 
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const char* memaddr)
+{
+  CCheevos::Get().ActivateAchievement(cheevo_id, memaddr);
+
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CGameLibRetro::GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
+                                                            unsigned cheevo_id))
+{
+  CCheevos::Get().GetCheevo_URL_ID(Callback);
   return GAME_ERROR_NO_ERROR;
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -78,6 +78,7 @@ public:
                                const std::string& username,
                                const std::string& token,
                                unsigned int gameID) override;
+  GAME_ERROR SetRetroAchievementsCredentials(const char* username, const char* token);
   GAME_ERROR RCPostRichPresenceUrl(std::string& url,
                                    std::string& postData,
                                    const std::string& username,
@@ -86,7 +87,10 @@ public:
                                    const std::string& richPresence) override;
   GAME_ERROR RCEnableRichPresence(const std::string& script) override;
   GAME_ERROR RCGetRichPresenceEvaluation(std::string& evaluation, unsigned int consoleID) override;
+  GAME_ERROR ActivateAchievement(unsigned cheevo_id, const char* memaddr) override;
   GAME_ERROR RCResetRuntime() override;
+  GAME_ERROR GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
+                                               unsigned cheevo_id)) override;
 
 private:
   GAME_ERROR AudioAvailable();


### PR DESCRIPTION
This PR implement support for Achievements in ReteroPlayer. This PR is based on https://github.com/kodi-game/game.libretro/pull/67 , for adding support of RCheevos.
This PR is used by https://github.com/garbear/xbmc/pull/126 for implementing Achievements.