### PR TITLE
Allow topology to specify device type and subclass

### DIFF
--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include "input/InputTypes.h"
+
 #include <kodi/addon-instance/Game.h>
+#include <libretro-common/libretro.h>
 
 #include <memory>
 #include <string>
@@ -46,6 +49,9 @@ namespace LIBRETRO
     bool SetController(const std::string &portAddress, const std::string &controllerId, bool bProvidesInput);
     void RemoveController(const std::string &portAddress);
 
+    libretro_device_t TypeOverride(const std::string &portAddress, const std::string &controllerId) const;
+    libretro_subclass_t SubclassOverride(const std::string &portAddress, const std::string &controllerId) const;
+
     int PlayerLimit() const { return m_playerLimit; }
 
   private:
@@ -78,6 +84,8 @@ namespace LIBRETRO
       std::string controllerId;
       std::vector<PortPtr> ports;
       bool bProvidesInput;
+      libretro_device_t type = RETRO_DEVICE_NONE;
+      libretro_subclass_t subclass = RETRO_SUBCLASS_NONE;
     };
 
     static unsigned int GetPlayerCount(const PortPtr& port);
@@ -98,11 +106,18 @@ namespace LIBRETRO
     static bool SetController(const ControllerPtr &controller, const std::string &portAddress, const std::string &controllerId, bool bProvidesInput);
     static void RemoveController(const ControllerPtr &controller, const std::string &portAddress);
 
+    static libretro_device_t TypeOverride(const std::vector<PortPtr>& ports, const std::string& controllerAddress);
+    static libretro_subclass_t SubclassOverride(const std::vector<PortPtr>& ports, const std::string& controllerAddress);
+
+    static libretro_device_t TypeOverride(const std::vector<ControllerPtr>& controllers, const std::string& controllerAddress);
+    static libretro_subclass_t SubclassOverride(const std::vector<ControllerPtr>& controllers, const std::string &controllerAddress);
+
     static PortPtr CreateDefaultPort(const std::string &acceptedController);
 
     static const ControllerPtr& GetActiveController(const PortPtr& port);
 
     static void SplitAddress(const std::string &address, std::string &nodeId, std::string &remainingAddress);
+    static std::string JoinAddress(const std::string& address, const std::string& nodeId);
 
     std::vector<PortPtr> m_ports;
     int m_playerLimit = -1;

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -29,6 +29,8 @@
 #define TOPOLOGY_XML_ATTR_CONNECTION_PORT   "connectionPort"
 #define TOPOLOGY_XML_ATTR_FORCE_CONNECTED   "forceConnected"
 #define TOPOLOGY_XML_ATTR_CONTROLLER_ID     "controller"
+#define TOPOLOGY_XML_ATTR_DEVICE_TYPE       "type"
+#define TOPOLOGY_XML_ATTR_DEVICE_SUBCLASS   "subclass"
 
 // Game API strings
 #define PORT_TYPE_KEYBOARD    "keyboard"

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -124,6 +124,16 @@ libretro_device_t CInputManager::ConnectController(const std::string &address, c
       {
         DevicePtr device(new CLibretroDevice(controllerId));
 
+        // Check topology for type/subclass override
+        libretro_device_t typeOverride = CControllerTopology::GetInstance().TypeOverride(address, controllerId);
+        libretro_subclass_t subclassOverride = CControllerTopology::GetInstance().SubclassOverride(address, controllerId);
+
+        if (typeOverride != RETRO_DEVICE_NONE)
+          device->SetType(typeOverride);
+        if (subclassOverride != RETRO_SUBCLASS_NONE)
+          device->SetSubclass(typeOverride);
+
+        // Calculate type value to send to libretro
         if (device->Subclass() != RETRO_SUBCLASS_NONE)
           deviceType = RETRO_DEVICE_SUBCLASS(device->Type(), device->Subclass());
         else

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -35,6 +35,9 @@ namespace LIBRETRO
     const FeatureMap& Features(void) const { return m_featureMap; }
     CLibretroDeviceInput& Input() { return *m_input; }
 
+    void SetType(libretro_device_t type) { m_type = type; }
+    void SetSubclass(libretro_subclass_t subclass) { m_subclass = subclass; }
+
     bool Deserialize(const TiXmlElement* pElement, unsigned int buttonMapVersion);
 
   private:


### PR DESCRIPTION
## Description

This PR allows topology.xml to specify a libretro device type and subclass. The attributes are optional, and if specified will override the values in buttonmap.xml.

The goal is to have a buttonmap like the following:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<logicaltopology>
  <port type="controller" id="1">
    <accepts controller="game.controller.genesis.3button"/>
    <accepts controller="game.controller.genesis.6button"/>
    <accepts controller="game.controller.genesis.teamplayer">
      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.genesis.3button" type="RETRO_DEVICE_JOYPAD" subclass="5"/>
        <accepts controller="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="6"/>
      </port>
      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.genesis.3button" type="RETRO_DEVICE_JOYPAD" subclass="5"/>
        <accepts controller="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="6"/>
      </port>
      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.genesis.3button" type="RETRO_DEVICE_JOYPAD" subclass="5"/>
        <accepts controller="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="6"/>
      </port>
      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
        <accepts controller="game.controller.genesis.3button" type="RETRO_DEVICE_JOYPAD" subclass="5"/>
        <accepts controller="game.controller.genesis.6button" type="RETRO_DEVICE_JOYPAD" subclass="6"/>
      </port>
    </accepts>
    <accepts controller="game.controller.genesis.mouse"/>
  </port>
  ...
</logicaltopology>
```

## Motiviation and context

Discussed with @KOPRajs here: https://github.com/kodi-game/controller-topology-project/pull/206#issuecomment-1423039687

## How has this been tested?

Compiles successfully.

Test builds: https://github.com/garbear/xbmc/releases