### PR TITLE
 Fix add-on using console to log

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -69,6 +69,8 @@ ADDON_STATUS CGameLibRetro::Create()
     if (dllPath.empty())
       throw ADDON_STATUS_UNKNOWN;
 
+    CLog::Get().SetType(SYS_LOG_TYPE_ADDON);
+
     if (!m_client.Load(dllPath))
     {
       esyslog("Failed to load %s", dllPath.c_str());

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -48,7 +48,9 @@ bool CLog::SetType(SYS_LOG_TYPE type)
   case SYS_LOG_TYPE_NULL:
     SetPipe(nullptr);
     break;
-  case SYS_LOG_TYPE_ADDON: // Must be set through SetPipe() because CLogAddon has no default constructor
+  case SYS_LOG_TYPE_ADDON:
+    SetPipe(new CLogAddon);
+    break;
   default:
     Log(SYS_LOG_ERROR, "Failed to set log type to %s", TypeToString(type));
     return false;
@@ -59,8 +61,6 @@ bool CLog::SetType(SYS_LOG_TYPE type)
 
 void CLog::SetPipe(ILog* pipe)
 {
-  std::unique_lock<std::mutex> lock(m_mutex);
-
   delete m_pipe;
   m_pipe = pipe;
 }

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -44,7 +44,6 @@ namespace LIBRETRO
     ~CLog(void);
 
     bool SetType(SYS_LOG_TYPE type);
-    void SetPipe(ILog* pipe);
     void SetLevel(SYS_LOG_LEVEL level);
     void SetLogPrefix(const std::string& strLogPrefix);
 
@@ -53,6 +52,8 @@ namespace LIBRETRO
     static const char* TypeToString(SYS_LOG_TYPE type);
 
   private:
+    void SetPipe(ILog* pipe);
+
     static const char* GetLogPrefix(SYS_LOG_LEVEL level);
 
     ILog*            m_pipe;


### PR DESCRIPTION
## Description

This PR fixes using the console to log. Instead, we should use Kodi APIs.

Console logging was added for the CI script in case it needed to run code here in a shell. However, we currently don't do this. Also, we should use the add-on API to log inside an add-on. Therefore, fixing the logging pipe is the best approach.

## How has this been tested?

Tested by pushing keyboard keys inside DOSBox, which previously didn't log the debug output in console mode. After applying the patch, debug log lines successfully log:

```
debug <general>: Keyboard: scancode: 0x30, sym: 0x62, unicode: 0x62, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "b" (RETROK_b) modifier 0x00000000: down
debug <general>: Keyboard: scancode: 0x30, sym: 0x62, unicode: 0x00, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "b" (RETROK_b) modifier 0x00000000: up
debug <general>: Keyboard: scancode: 0x30, sym: 0x62, unicode: 0x62, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "b" (RETROK_b) modifier 0x00000000: down
debug <general>: Keyboard: scancode: 0x30, sym: 0x62, unicode: 0x00, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "b" (RETROK_b) modifier 0x00000000: up
debug <general>: Keyboard: scancode: 0x1e, sym: 0x61, unicode: 0x61, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "a" (RETROK_a) modifier 0x00000000: down
debug <general>: Keyboard: scancode: 0x1e, sym: 0x61, unicode: 0x00, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "a" (RETROK_a) modifier 0x00000000: up
debug <general>: Keyboard: scancode: 0xd, sym: 0x3d, unicode: 0x3d, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "equals" (RETROK_EQUALS) modifier 0x00000000: down
debug <general>: Keyboard: scancode: 0xd, sym: 0x3d, unicode: 0x00, modifier: 0x0
debug <general>: AddOnLog: game.libretro.dosbox: Controller "game.controller.keyboard" key "equals" (RETROK_EQUALS) modifier 0x00000000: up
```