### PR TITLE
Fix segfault when logging before Add-on Log Interface is up

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -69,6 +69,8 @@ ADDON_STATUS CGameLibRetro::Create()
     if (dllPath.empty())
       throw ADDON_STATUS_UNKNOWN;
 
+    CLog::Get().SetType(SYS_LOG_TYPE_ADDON);
+
     if (!m_client.Load(dllPath))
     {
       esyslog("Failed to load %s", dllPath.c_str());

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -48,7 +48,9 @@ bool CLog::SetType(SYS_LOG_TYPE type)
   case SYS_LOG_TYPE_NULL:
     SetPipe(nullptr);
     break;
-  case SYS_LOG_TYPE_ADDON: // Must be set through SetPipe() because CLogAddon has no default constructor
+  case SYS_LOG_TYPE_ADDON:
+    SetPipe(new CLogAddon);
+    break;
   default:
     Log(SYS_LOG_ERROR, "Failed to set log type to %s", TypeToString(type));
     return false;
@@ -59,8 +61,6 @@ bool CLog::SetType(SYS_LOG_TYPE type)
 
 void CLog::SetPipe(ILog* pipe)
 {
-  std::unique_lock<std::mutex> lock(m_mutex);
-
   delete m_pipe;
   m_pipe = pipe;
 }

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -44,7 +44,6 @@ namespace LIBRETRO
     ~CLog(void);
 
     bool SetType(SYS_LOG_TYPE type);
-    void SetPipe(ILog* pipe);
     void SetLevel(SYS_LOG_LEVEL level);
     void SetLogPrefix(const std::string& strLogPrefix);
 
@@ -53,6 +52,8 @@ namespace LIBRETRO
     static const char* TypeToString(SYS_LOG_TYPE type);
 
   private:
+    void SetPipe(ILog* pipe);
+
     static const char* GetLogPrefix(SYS_LOG_LEVEL level);
 
     ILog*            m_pipe;


### PR DESCRIPTION
## Description

A few months ago I hit a segfault and wrote a fix for it. Now I'm PRing the fix.

## How has this been tested?

Tested with my latest build: https://github.com/garbear/xbmc/releases

I was able to reproduce the segfault. After applying the fix, there is no more segfault.