### PR TITLE
Add support for OEM 102nd key

### DIFF
--- a/src/input/DefaultKeyboardDefines.h
+++ b/src/input/DefaultKeyboardDefines.h
@@ -146,3 +146,4 @@
 #define DEFAULT_KEYBOARD_FEATURE_POWER           "power"
 #define DEFAULT_KEYBOARD_FEATURE_EURO            "euro"
 #define DEFAULT_KEYBOARD_FEATURE_UNDO            "undo"
+#define DEFAULT_KEYBOARD_FEATURE_OEM_102         "oem102"

--- a/src/input/DefaultKeyboardTranslator.cpp
+++ b/src/input/DefaultKeyboardTranslator.cpp
@@ -152,6 +152,7 @@ int CDefaultKeyboardTranslator::GetLibretroIndex(const std::string &strFeatureNa
   if (strFeatureName == DEFAULT_KEYBOARD_FEATURE_POWER)         return RETROK_POWER;
   if (strFeatureName == DEFAULT_KEYBOARD_FEATURE_EURO)          return RETROK_EURO;
   if (strFeatureName == DEFAULT_KEYBOARD_FEATURE_UNDO)          return RETROK_UNDO;
+  if (strFeatureName == DEFAULT_KEYBOARD_FEATURE_OEM_102)       return RETROK_OEM_102;
 
   return -1;
 }

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -339,6 +339,7 @@ namespace LIBRETRO
         { "RETROK_POWER",          RETROK_POWER },
         { "RETROK_EURO",           RETROK_EURO },
         { "RETROK_UNDO",           RETROK_UNDO },
+        { "RETROK_OEM_102",        RETROK_OEM_102 },
       }
     },
   };
@@ -575,6 +576,7 @@ const char* LibretroTranslator::GetFeatureName(libretro_device_t type, unsigned 
     case RETROK_POWER:          return "RETROK_POWER";
     case RETROK_EURO:           return "RETROK_EURO";
     case RETROK_UNDO:           return "RETROK_UNDO";
+    case RETROK_OEM_102:        return "RETROK_OEM_102";
     default:
       break;
     }


### PR DESCRIPTION
## Description

This adds support for the OEM key present on 102-key keyboards (non-US).

## Related PRs

Requires:

* https://github.com/kodi-game/controller-topology-project/pull/279
* https://github.com/xbmc/xbmc/pull/24202.

Added to libretro in https://github.com/libretro/RetroArch/pull/7173