### PR TITLE
Allow analog input for RETRO_DEVICE_JOYPAD

### DIFF
--- a/src/input/LibretroDeviceInput.cpp
+++ b/src/input/LibretroDeviceInput.cpp
@@ -34,6 +34,8 @@ CLibretroDeviceInput::CLibretroDeviceInput(const std::string &controllerId)
   {
     case RETRO_DEVICE_JOYPAD:
       m_buttons.resize(LIBRETRO_JOYPAD_BUTTON_COUNT);
+      m_analogButtons.resize(LIBRETRO_JOYPAD_BUTTON_COUNT);
+      m_analogSticks.resize(LIBRETRO_ANALOG_STICK_COUNT);
       break;
 
     case RETRO_DEVICE_MOUSE:


### PR DESCRIPTION
## Description

As title says, this PR allows analog button/stick input even if the type is `RETRO_DEVICE_JOYPAD`.

This is to allow support for analog stick input in Vice. Vice requires the device type to be `RETRO_DEVICE_JOYPAD`, but still queries for analog stick values, so don't throw these values away.

Even though Vice requires the type to be `RETRO_DEVICE_JOYPAD`, you can see it checking analog stick values here: https://github.com/libretro/vice-libretro/blob/master/libretro/libretro-mapper.c#L1046-L1049

## How has this been tested?

Will test when vice cores have been updated.