### PR TITLE
Add CXX language to CMakeLists.txt to fix Appveyor error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(game.libretro)
+project(game.libretro LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
## Description

Currently, Appveyor is passing for Win32 and Win64 but failing for WindowsStore x64 and WindowsStore ARM. See results of last build: https://ci.appveyor.com/project/kodi-game/game-libretro/builds/48708315

## How has this been tested?

Before, Appveyor error was:

  -- The C compiler identification is unknown
  -- The CXX compiler identification is MSVC 19.38.33130.0
  CMake Error at CMakeLists.txt:2 (project):
    No CMAKE_C_COMPILER could be found.

With this PR, we'll see if Appveyor succeeds on all platforms.