### PR TITLE
Move callback initialization after retro_init()

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -85,7 +85,7 @@ ADDON_STATUS CGameLibRetro::Create()
     }
 
     // Environment must be initialized before calling retro_init()
-    CLibretroEnvironment::Get().Initialize(this, &m_client, &m_clientBridge);
+    CLibretroEnvironment::Get().InitializeEnvironment(this, &m_client, &m_clientBridge);
     CCheevosEnvironment::Get().Initialize();
 
     CButtonMapper::Get().LoadButtonMap();
@@ -94,6 +94,8 @@ ADDON_STATUS CGameLibRetro::Create()
     CCheevos::Get().Initialize();
 
     m_client.retro_init();
+
+    CLibretroEnvironment::Get().InitializeCallbacks();
 
     // Log core info
     retro_system_info systemInfo = { };

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -44,9 +44,9 @@ CLibretroEnvironment& CLibretroEnvironment::Get(void)
   return _instance;
 }
 
-void CLibretroEnvironment::Initialize(CGameLibRetro* addon,
-                                      CLibretroDLL* client,
-                                      CClientBridge* clientBridge)
+void CLibretroEnvironment::InitializeEnvironment(CGameLibRetro* addon,
+                                                 CLibretroDLL* client,
+                                                 CClientBridge* clientBridge)
 {
   m_addon = addon;
   m_client = client;
@@ -60,7 +60,10 @@ void CLibretroEnvironment::Initialize(CGameLibRetro* addon,
 
   // Install environment callback
   m_client->retro_set_environment(EnvCallback);
+}
 
+void CLibretroEnvironment::InitializeCallbacks()
+{
   // Install remaining callbacks
   m_client->retro_set_video_refresh(CFrontendBridge::VideoRefresh);
   m_client->retro_set_audio_sample(CFrontendBridge::AudioFrame);

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -32,9 +32,10 @@ namespace LIBRETRO
   public:
     static CLibretroEnvironment& Get(void);
 
-    void Initialize(CGameLibRetro* addon,
-                    CLibretroDLL* client,
-                    CClientBridge* clientBridge);
+    void InitializeEnvironment(CGameLibRetro* addon,
+                               CLibretroDLL* client,
+                               CClientBridge* clientBridge);
+    void InitializeCallbacks();
 
     void Deinitialize(void);
 


### PR DESCRIPTION
## Description

This PR splits CLibretroEnvironment::Initialize() into two functions:

* CLibretroEnvironment::InitializeEnvironment()
* CLibretroEnvironment::InitializeCallbacks()

The purpose is to move callback initialization after retro_init(). Setting callbacks before retro_init() causes Mesen to crash.

Upon inspection of RetroArch, their code sets callbacks after retro_init() also, so this should be a safe move.

## Motivation and context

Reported here: https://forum.kodi.tv/showthread.php?tid=173361&pid=3180238#pid3180238

## How has this been tested?

Before: Mesen segfaults when setting callbacks

After: Mesen loads successfully
