### PR TITLE
[Backport] Allow topology to specify device type and subclass

### DIFF
--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include "input/InputTypes.h"
+
 #include <kodi/addon-instance/Game.h>
+#include <libretro-common/libretro.h>
 
 #include <memory>
 #include <string>
@@ -46,6 +49,9 @@ namespace LIBRETRO
     bool SetController(const std::string &portAddress, const std::string &controllerId, bool bProvidesInput);
     void RemoveController(const std::string &portAddress);
 
+    libretro_device_t TypeOverride(const std::string &portAddress, const std::string &controllerId) const;
+    libretro_subclass_t SubclassOverride(const std::string &portAddress, const std::string &controllerId) const;
+
     int PlayerLimit() const { return m_playerLimit; }
 
   private:
@@ -78,6 +84,8 @@ namespace LIBRETRO
       std::string controllerId;
       std::vector<PortPtr> ports;
       bool bProvidesInput;
+      libretro_device_t type = RETRO_DEVICE_NONE;
+      libretro_subclass_t subclass = RETRO_SUBCLASS_NONE;
     };
 
     static unsigned int GetPlayerCount(const PortPtr& port);
@@ -98,11 +106,18 @@ namespace LIBRETRO
     static bool SetController(const ControllerPtr &controller, const std::string &portAddress, const std::string &controllerId, bool bProvidesInput);
     static void RemoveController(const ControllerPtr &controller, const std::string &portAddress);
 
+    static libretro_device_t TypeOverride(const std::vector<PortPtr>& ports, const std::string& controllerAddress);
+    static libretro_subclass_t SubclassOverride(const std::vector<PortPtr>& ports, const std::string& controllerAddress);
+
+    static libretro_device_t TypeOverride(const std::vector<ControllerPtr>& controllers, const std::string& controllerAddress);
+    static libretro_subclass_t SubclassOverride(const std::vector<ControllerPtr>& controllers, const std::string &controllerAddress);
+
     static PortPtr CreateDefaultPort(const std::string &acceptedController);
 
     static const ControllerPtr& GetActiveController(const PortPtr& port);
 
     static void SplitAddress(const std::string &address, std::string &nodeId, std::string &remainingAddress);
+    static std::string JoinAddress(const std::string& address, const std::string& nodeId);
 
     std::vector<PortPtr> m_ports;
     int m_playerLimit = -1;

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -29,6 +29,8 @@
 #define TOPOLOGY_XML_ATTR_CONNECTION_PORT   "connectionPort"
 #define TOPOLOGY_XML_ATTR_FORCE_CONNECTED   "forceConnected"
 #define TOPOLOGY_XML_ATTR_CONTROLLER_ID     "controller"
+#define TOPOLOGY_XML_ATTR_DEVICE_TYPE       "type"
+#define TOPOLOGY_XML_ATTR_DEVICE_SUBCLASS   "subclass"
 
 // Game API strings
 #define PORT_TYPE_KEYBOARD    "keyboard"

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -123,6 +123,16 @@ libretro_device_t CInputManager::ConnectController(const std::string &address, c
       {
         DevicePtr device(new CLibretroDevice(controllerId));
 
+        // Check topology for type/subclass override
+        libretro_device_t typeOverride = CControllerTopology::GetInstance().TypeOverride(address, controllerId);
+        libretro_subclass_t subclassOverride = CControllerTopology::GetInstance().SubclassOverride(address, controllerId);
+
+        if (typeOverride != RETRO_DEVICE_NONE)
+          device->SetType(typeOverride);
+        if (subclassOverride != RETRO_SUBCLASS_NONE)
+          device->SetSubclass(typeOverride);
+
+        // Calculate type value to send to libretro
         if (device->Subclass() != RETRO_SUBCLASS_NONE)
           deviceType = RETRO_DEVICE_SUBCLASS(device->Type(), device->Subclass());
         else

--- a/src/input/LibretroDevice.h
+++ b/src/input/LibretroDevice.h
@@ -35,6 +35,9 @@ namespace LIBRETRO
     const FeatureMap& Features(void) const { return m_featureMap; }
     CLibretroDeviceInput& Input() { return *m_input; }
 
+    void SetType(libretro_device_t type) { m_type = type; }
+    void SetSubclass(libretro_subclass_t subclass) { m_subclass = subclass; }
+
     bool Deserialize(const TiXmlElement* pElement, unsigned int buttonMapVersion);
 
   private:


### PR DESCRIPTION
## Description

Backport of https://github.com/kodi-game/game.libretro/pull/105.

## Motivation and context

I came across a topology.xml file with a specified type/subclass in one of our 160 game add-ons. Can't hurt to have this change backported in case it can help with this one add-on.

## How has this been tested:

Included in RetroPlayer test builds since [2023-02-12)](https://github.com/garbear/xbmc/releases/tag/retroplayer-20-20230212): https://github.com/garbear/xbmc/releases