### PR TITLE
Fix broken input in Nintendo DS cores

### DIFF
--- a/src/input/LibretroDevice.cpp
+++ b/src/input/LibretroDevice.cpp
@@ -75,7 +75,7 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
 
   // Features
   const TiXmlElement* pFeature = pElement->FirstChildElement(BUTTONMAP_XML_ELM_FEATURE);
-  while (pFeature)
+  for (; pFeature != nullptr; pFeature = pFeature->NextSiblingElement(BUTTONMAP_XML_ELM_FEATURE))
   {
     const char* name = pFeature->Attribute(BUTTONMAP_XML_ATTR_FEATURE_NAME);
     if (!name)
@@ -99,7 +99,7 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
     if (LibretroTranslator::GetFeatureIndex(libretroFeature.feature) < 0)
     {
       esyslog("<%s> tag has invalid \"%s\" attribute: \"%s\"", BUTTONMAP_XML_ELM_FEATURE, BUTTONMAP_XML_ATTR_FEATURE_MAPTO, mapto);
-      return false;
+      continue;
     }
 
     if (axis != nullptr)
@@ -110,13 +110,11 @@ bool CLibretroDevice::Deserialize(const TiXmlElement* pElement, unsigned int but
       if (LibretroTranslator::GetAxisID(libretroFeature.axis) < 0)
       {
         esyslog("<%s> tag has invalid \"%s\" attribute: \"%s\"", BUTTONMAP_XML_ELM_FEATURE, BUTTONMAP_XML_ATTR_FEATURE_AXIS, axis);
-        return false;
+        continue;
       }
     }
 
     m_featureMap[name] = std::move(libretroFeature);
-
-    pFeature = pFeature->NextSiblingElement(BUTTONMAP_XML_ELM_FEATURE);
   }
 
   return true;


### PR DESCRIPTION
## Description

The DeSmuME buttonmap added in https://github.com/kodi-game/game.libretro.desmume/pull/4 contains the `RETRO_DEVICE_POINTER` feature, however apparently relative pointers are unimplemented: https://github.com/kodi-game/game.libretro/blob/2cb1ed77d3a31d73301447c60f600eaebccd2f07/src/libretro/LibretroTranslator.cpp#L617

```c++
case RETRO_DEVICE_POINTER:
{
  break; // TODO
}
```

This was breaking the input for NDS cores, as the game.controller.nds layout wouldn't match to any libretro features.

## How has this been tested?

Before: Error about `RETRO_DEVICE_POINTER` not defined for `mapto` XML attribute, no input, empty controller in the in-game "Controls" button mapper.

After: Buttons appear in the in-game controller mapper, input works.