### PR TITLE
Fix framebuffer incongruity

### DIFF
--- a/src/video/VideoStream.cpp
+++ b/src/video/VideoStream.cpp
@@ -106,13 +106,15 @@ bool CVideoStream::GetSwFramebuffer(unsigned int width, unsigned int height, GAM
   if (!m_stream.IsOpen() || m_streamType != GAME_STREAM_SW_FRAMEBUFFER)
     return false;
 
-  if (!m_framebuffer)
+  if (m_framebuffer != nullptr)
   {
-    m_framebuffer.reset(new game_stream_buffer{});
-
-    if (!m_stream.GetBuffer(width, height, *m_framebuffer))
-      return false;
+    m_stream.ReleaseBuffer(*m_framebuffer);
   }
+
+  m_framebuffer.reset(new game_stream_buffer{});
+
+  if (!m_stream.GetBuffer(width, height, *m_framebuffer))
+    return false;
 
   framebuffer = m_framebuffer->sw_framebuffer;
 


### PR DESCRIPTION
Fixes memory corruption issue when core requests second software framebuffer of different size within the same run, which can lead to memory corruption in the form of buffer overflow, by releasing the current buffer and providing a new one of the correct size.

This was the case with pcsx_rearmed at least.

I just noticed that the same issue could occur with a hardware framebuffer. I will submit a PR for that if/when I have time, or someone else could beat me to it 😄 .