### PR TITLE
[Backport][Nexus] Fix framebuffer incongruity

### DIFF
--- a/src/video/VideoStream.cpp
+++ b/src/video/VideoStream.cpp
@@ -106,13 +106,15 @@ bool CVideoStream::GetSwFramebuffer(unsigned int width, unsigned int height, GAM
   if (!m_stream.IsOpen() || m_streamType != GAME_STREAM_SW_FRAMEBUFFER)
     return false;
 
-  if (!m_framebuffer)
+  if (m_framebuffer != nullptr)
   {
-    m_framebuffer.reset(new game_stream_buffer{});
-
-    if (!m_stream.GetBuffer(width, height, *m_framebuffer))
-      return false;
+    m_stream.ReleaseBuffer(*m_framebuffer);
   }
+
+  m_framebuffer.reset(new game_stream_buffer{});
+
+  if (!m_stream.GetBuffer(width, height, *m_framebuffer))
+    return false;
 
   framebuffer = m_framebuffer->sw_framebuffer;
 


### PR DESCRIPTION
## Description

Backport of https://github.com/kodi-game/game.libretro/pull/126

## How has this been tested?

Testing is still in progress. One tester is waiting for https://github.com/LibreELEC/LibreELEC.tv/pull/9085 to be merged and shipped.