### PR TITLE
Game API v4.0.0: Hardware Rendering

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -276,6 +276,8 @@ GAME_ERROR CGameLibRetro::RunFrame()
   m_frameTimeLast = current;
   m_clientBridge.FrameTime(delta);
 
+  CLibretroEnvironment::Get().OnFrameBegin();
+
   m_client.retro_run();
 
   CLibretroEnvironment::Get().OnFrameEnd();

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -102,6 +102,11 @@ std::string CLibretroEnvironment::GetResourcePath(const char* relPath)
   return m_resources.GetFullPath(relPath);
 }
 
+void CLibretroEnvironment::OnFrameBegin()
+{
+  m_videoStream.OnFrameBegin();
+}
+
 void CLibretroEnvironment::OnFrameEnd()
 {
   m_videoStream.OnFrameEnd();
@@ -212,7 +217,7 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       if (typedData)
       {
         // Translate struct and report hw info to frontend
-        game_stream_hw_framebuffer_properties hw_info;
+        game_hw_rendering_properties hw_info;
         hw_info.context_type       = LibretroTranslator::GetHWContextType(typedData->context_type);
         hw_info.depth              = typedData->depth;
         hw_info.stencil            = typedData->stencil;
@@ -221,7 +226,9 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
         hw_info.version_minor      = typedData->version_minor;
         hw_info.cache_context      = typedData->cache_context;
         hw_info.debug_context      = typedData->debug_context;
-        if (!m_videoStream.EnableHardwareRendering(hw_info))
+
+        // Set up the video stream
+        if (!m_videoStream.EnableHardwareRendering())
           return false;
 
         // Store callbacks from libretro client
@@ -231,6 +238,10 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
         // Expose frontend callbacks to libretro client
         typedData->get_current_framebuffer = CFrontendBridge::HwGetCurrentFramebuffer;
         typedData->get_proc_address        = CFrontendBridge::HwGetProcAddress;
+
+        // Now that hooks are installed, enable HW rendering in the frontend
+        if (!m_addon->EnableHardwareRendering(hw_info))
+          return false;
       }
       break;
     }

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -67,6 +67,11 @@ namespace LIBRETRO
     std::string GetResourcePath(const char* relPath);
 
     /*!
+     * \brief Called before a game is run for a frame
+     */
+    void OnFrameBegin();
+
+    /*!
      * \brief Called after game has been run for a frame
      */
     void OnFrameEnd();

--- a/src/video/VideoStream.h
+++ b/src/video/VideoStream.h
@@ -28,7 +28,7 @@ namespace LIBRETRO
 
     void SetGeometry(const CVideoGeometry &geometry);
 
-    bool EnableHardwareRendering(const game_stream_hw_framebuffer_properties &properties);
+    bool EnableHardwareRendering();
 
     uintptr_t GetHwFramebuffer();
     bool GetSwFramebuffer(unsigned int width, unsigned int height, GAME_PIXEL_FORMAT requestedFormat, game_stream_sw_framebuffer_buffer &framebuffer);
@@ -37,6 +37,7 @@ namespace LIBRETRO
     void DupeFrame() { } // Not supported
     void RenderHwFrame();
 
+    void OnFrameBegin();
     void OnFrameEnd();
 
   private:


### PR DESCRIPTION
## Description

This PR contains the changes needed to account for the hardware rendering API changes in https://github.com/xbmc/xbmc/pull/26091.

The main change is that, because hardware rendering properties must be known before opening the stream, a new callback has been added which is invoked before the stream is opened. And when opening the stream, no parameters are now needed.

## How has this been tested?

#### CI testing

CI on Azure succeeds. Jenkins is hard-coded to master and thus fails.

#### Runtime testing

Tested as part of https://github.com/xbmc/xbmc/pull/26091

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-21.1-20241213
