### PR TITLE
Fix input for daisy-chained controllers

### DIFF
--- a/src/input/ControllerTopology.cpp
+++ b/src/input/ControllerTopology.cpp
@@ -201,6 +201,9 @@ int CControllerTopology::GetPortIndex(const ControllerPtr &controller, const std
 {
   int portIndex = -1;
 
+  if (controller->bProvidesInput)
+    playerCount++;
+
   std::string portControllerId;
   std::string remainingAddress;
   SplitAddress(portAddress, portControllerId, remainingAddress);
@@ -216,9 +219,6 @@ int CControllerTopology::GetPortIndex(const ControllerPtr &controller, const std
         break;
     }
   }
-
-  if (controller->bProvidesInput)
-    playerCount++;
 
   return portIndex;
 }


### PR DESCRIPTION
## Description

The recursive counting of port indexes was broken. As a result, with 3DO, controller input is always assigned to the first port (port 0).

After this PR, controllers 2-8 correctly assign to the right libretro port.

## How has this been tested?

Tested on my 21.1 test branch.

Included in latest round of test builds: https://github.com/garbear/xbmc/releases

### Before

All 8 controllers assigned to port 0:

```
debug <general>: AddOnLog: game.libretro.opera: Libretro input bindings:
debug <general>: AddOnLog: game.libretro.opera: ------------------------------------------------------------
debug <general>: AddOnLog: game.libretro.opera: Port: 0
debug <general>: AddOnLog: game.libretro.opera: ------------------------------------------------------------
```

### After

All 8 controllers assigned to correct libretro ports:

```
debug <general>: AddOnLog: game.libretro.opera: Libretro input bindings:
debug <general>: AddOnLog: game.libretro.opera: ------------------------------------------------------------
debug <general>: AddOnLog: game.libretro.opera: Port: 0
debug <general>: AddOnLog: game.libretro.opera: Port: 1
debug <general>: AddOnLog: game.libretro.opera: Port: 2
debug <general>: AddOnLog: game.libretro.opera: Port: 3
debug <general>: AddOnLog: game.libretro.opera: Port: 4
debug <general>: AddOnLog: game.libretro.opera: Port: 5
debug <general>: AddOnLog: game.libretro.opera: Port: 6
debug <general>: AddOnLog: game.libretro.opera: Port: 7
debug <general>: AddOnLog: game.libretro.opera: ------------------------------------------------------------
```
