### PR TITLE
Fix building with CMake 4.0

### DIFF
--- a/depends/common/libretro-common/CMakeLists.txt
+++ b/depends/common/libretro-common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...4.0)
 project(libretro-common)
 
 INSTALL(

--- a/depends/common/rcheevos/CMakeLists.txt
+++ b/depends/common/rcheevos/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(rcheevos)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...4.0)
 
 # Disable Lua for now
 add_definitions(-DRC_DISABLE_LUA)

--- a/depends/common/tinyxml/CMakeLists.txt
+++ b/depends/common/tinyxml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(tinyxml)
 
 set(SOURCES src/tinystr.cpp

--- a/depends/windows/dlfcn-win32/0001-Bump-policy_max-in-cmake_minimum_required-to-3.10.patch
+++ b/depends/windows/dlfcn-win32/0001-Bump-policy_max-in-cmake_minimum_required-to-3.10.patch
@@ -1,0 +1,22 @@
+From 07618bd719d09e6759312606851bd68793007c6c Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 4 Mar 2025 15:26:22 +0100
+Subject: [PATCH] Bump policy_max in cmake_minimum_required to 3.10
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e44343d..5ad0bb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8.11...3.10)
+ 
+ if (NOT DEFINED CMAKE_BUILD_TYPE)
+   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+-- 
+2.49.0
+

--- a/depends/windowsstore/dlfcn-win32/0001-Bump-policy_max-in-cmake_minimum_required-to-3.10.patch
+++ b/depends/windowsstore/dlfcn-win32/0001-Bump-policy_max-in-cmake_minimum_required-to-3.10.patch
@@ -1,0 +1,22 @@
+From 07618bd719d09e6759312606851bd68793007c6c Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 4 Mar 2025 15:26:22 +0100
+Subject: [PATCH] Bump policy_max in cmake_minimum_required to 3.10
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e44343d..5ad0bb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8.11...3.10)
+ 
+ if (NOT DEFINED CMAKE_BUILD_TYPE)
+   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+-- 
+2.49.0
+


### PR DESCRIPTION
## Description

This PR fixes building with CMake v4.0.

~dlfcn-win32 has been bumped to v1.4.2, which contains a fix for CMake 4.0~ unbumped, doens't build on UWP64 or ARM64

## How has this been tested?

Tested on Windows ARM in parallels using CMake 4.0. Games load successfully.