### PR TITLE
Game API v4.1.0: Add display aspect ratio to each video frame

### DIFF
--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -421,18 +421,14 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
     {
       const retro_system_av_info* typedData = reinterpret_cast<const retro_system_av_info*>(data);
-      if (!typedData)
-        return false;
+      if (typedData)
+      {
+        UpdateVideoGeometry(typedData->geometry);
 
-      CVideoGeometry videoGeometry(typedData->geometry);
-      m_videoStream.SetGeometry(videoGeometry);
-
-      //! @todo Reopen streams if geometry changes
-
-      //! @todo Report updating timing info to frontend
-      const double fps = typedData->timing.fps;
-      const double sampleRate = typedData->timing.sample_rate;
-
+        //! @todo Report updated timing info to frontend
+        const double fps = typedData->timing.fps;
+        const double sampleRate = typedData->timing.sample_rate;
+      }
       break;
     }
   case RETRO_ENVIRONMENT_SET_PROC_ADDRESS_CALLBACK:
@@ -477,8 +473,7 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
     const retro_game_geometry* typedData = reinterpret_cast<const retro_game_geometry*>(data);
     if (typedData)
     {
-      // Not implemented
-      return false;
+      UpdateVideoGeometry(*typedData);
     }
     break;
   }

--- a/src/video/VideoGeometry.cpp
+++ b/src/video/VideoGeometry.cpp
@@ -21,5 +21,11 @@ void CVideoGeometry::UpdateVideoGeometry(const retro_game_geometry &geometry)
   m_nominalHeight = geometry.base_height;
   m_maxWidth = geometry.max_width;
   m_maxHeight = geometry.max_height;
-  m_aspectRatio = geometry.aspect_ratio;
+
+  // If aspect_ratio is <= 0.0, libretro assumes an aspect ratio of
+  // base_width / base_height, i.e. square pixels
+  if (geometry.aspect_ratio <= 0.0f)
+    m_displayAspectRatio = 0.0f;
+  else
+    m_displayAspectRatio = geometry.aspect_ratio;
 }

--- a/src/video/VideoGeometry.h
+++ b/src/video/VideoGeometry.h
@@ -24,13 +24,13 @@ namespace LIBRETRO
     unsigned int NominalHeight() const { return m_nominalHeight; }
     unsigned int MaxWidth() const { return m_maxWidth; }
     unsigned int MaxHeight() const { return m_maxHeight; }
-    float AspectRatio() const { return m_aspectRatio; }
+    float DisplayAspectRatio() const { return m_displayAspectRatio; }
 
   private:
     unsigned int m_nominalWidth = 0;
     unsigned int m_nominalHeight = 0;
     unsigned int m_maxWidth = 0;
     unsigned int m_maxHeight = 0;
-    float m_aspectRatio = 0.0f;
+    float m_displayAspectRatio = 0.0f; // A value of 0.0f indicates square pixels
   };
 }

--- a/src/video/VideoStream.cpp
+++ b/src/video/VideoStream.cpp
@@ -85,9 +85,9 @@ bool CVideoStream::GetSwFramebuffer(unsigned int width, unsigned int height, GAM
     properties.sw_framebuffer.format = requestedFormat;
     properties.sw_framebuffer.nominal_width = m_geometry->NominalWidth();
     properties.sw_framebuffer.nominal_height = m_geometry->NominalHeight();
+    properties.sw_framebuffer.nominal_display_aspect_ratio = m_geometry->DisplayAspectRatio();
     properties.sw_framebuffer.max_width = m_geometry->MaxWidth();
     properties.sw_framebuffer.max_height = m_geometry->MaxHeight();
-    properties.sw_framebuffer.aspect_ratio = m_geometry->AspectRatio();
 
     m_stream.Open(properties);
     m_streamType = GAME_STREAM_SW_FRAMEBUFFER;
@@ -134,9 +134,9 @@ void CVideoStream::AddFrame(const uint8_t* data, unsigned int size, unsigned int
     properties.video.format = format;
     properties.video.nominal_width = m_geometry->NominalWidth();
     properties.video.nominal_height = m_geometry->NominalHeight();
+    properties.video.nominal_display_aspect_ratio = m_geometry->DisplayAspectRatio();
     properties.video.max_width = m_geometry->MaxWidth();
     properties.video.max_height = m_geometry->MaxHeight();
-    properties.video.aspect_ratio = m_geometry->AspectRatio();
 
     m_stream.Open(properties);
     m_streamType = GAME_STREAM_VIDEO;
@@ -157,6 +157,7 @@ void CVideoStream::AddFrame(const uint8_t* data, unsigned int size, unsigned int
     packet.type = GAME_STREAM_VIDEO;
     packet.video.width = width;
     packet.video.height = height;
+    packet.video.display_aspect_ratio = m_geometry->DisplayAspectRatio();
     packet.video.rotation = rotation;
     packet.video.data = data;
     packet.video.size = size;
@@ -167,6 +168,7 @@ void CVideoStream::AddFrame(const uint8_t* data, unsigned int size, unsigned int
     packet.type = GAME_STREAM_SW_FRAMEBUFFER;
     packet.sw_framebuffer.width = width;
     packet.sw_framebuffer.height = height;
+    packet.sw_framebuffer.display_aspect_ratio = m_geometry->DisplayAspectRatio();
     packet.sw_framebuffer.rotation = rotation;
     packet.sw_framebuffer.data = data;
     packet.sw_framebuffer.size = size;


### PR DESCRIPTION
## Description

This PR accompanies the Game API change to send the DAR every video frame.

DAR is cached in game.libretro when set by libretro, and the cache is used to report the frame DAR. Geometry info can arrive async, so if the game changes its dimensions, it is expected for the core to update the DAR async if desired, or it'll continue to render at the original DAR.

## Related PRs and Issues

Requires https://github.com/xbmc/xbmc/pull/26923.

## How has this been tested?

Verified that the DAR is plumbed through to the GL renderer on macOS ARM with Mr. Boom:

<img width="367" alt="Screenshot 2025-06-28 at 8 50 51 PM" src="https://github.com/user-attachments/assets/deebce11-45f8-4a8a-ae1c-485553a74e90" />

Further testing as part of https://github.com/xbmc/xbmc/pull/26923.