### PR TITLE
Fix SET_SYSTEM_AV_INFO return value

### DIFF
--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -421,14 +421,14 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
     {
       const retro_system_av_info* typedData = static_cast<const retro_system_av_info*>(data);
-      if (typedData)
-      {
-        UpdateVideoGeometry(typedData->geometry);
+      if (!typedData)
+        return false;
 
-        //! @todo Report updated timing info to frontend
-        const double fps = typedData->timing.fps;
-        const double sampleRate = typedData->timing.sample_rate;
-      }
+      UpdateVideoGeometry(typedData->geometry);
+
+      //! @todo Report updated timing info to frontend
+      const double fps = typedData->timing.fps;
+      const double sampleRate = typedData->timing.sample_rate;
       break;
     }
   case RETRO_ENVIRONMENT_SET_PROC_ADDRESS_CALLBACK:


### PR DESCRIPTION
Revert the change in return value of _RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO_ done in 2cf90e573490ef3b08551560a294a5c634c10685.

Discussed here: https://github.com/kodi-game/game.libretro/commit/2cf90e573490ef3b08551560a294a5c634c10685#r161876994
