### PR TITLE
Improve logging input devices

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -287,7 +287,7 @@ void CInputManager::LogInputDescriptors(const retro_input_descriptor* descriptor
     {
       dsyslog("Port: %u, Device: %s, Feature: %s, Description: %s",
           descriptor->port,
-          LibretroTranslator::GetDeviceName(descriptor->device),
+          LibretroTranslator::GetDeviceName(descriptor->device).c_str(),
           LibretroTranslator::GetFeatureName(descriptor->device, descriptor->index, descriptor->id),
           descriptor->description ? descriptor->description : "");
     }
@@ -295,7 +295,7 @@ void CInputManager::LogInputDescriptors(const retro_input_descriptor* descriptor
     {
       dsyslog("Port: %u, Device: %s, Feature: %s, Component: %s, Description: %s",
           descriptor->port,
-          LibretroTranslator::GetDeviceName(descriptor->device),
+          LibretroTranslator::GetDeviceName(descriptor->device).c_str(),
           LibretroTranslator::GetFeatureName(descriptor->device, descriptor->index, descriptor->id),
           component.c_str(),
           descriptor->description ? descriptor->description : "");
@@ -477,12 +477,12 @@ void CInputManager::SetControllerInfo(const retro_controller_info* info)
       {
         libretro_subclass_t subclass = (type.id >> RETRO_DEVICE_TYPE_SHIFT) - 1;
         dsyslog("  Device: %s, Subclass: %u, Description: \"%s\"",
-            LibretroTranslator::GetDeviceName(baseType), subclass, description.c_str());
+            LibretroTranslator::GetDeviceName(baseType).c_str(), subclass, description.c_str());
       }
       else
       {
         dsyslog("  Device: %s, Description: \"%s\"",
-            LibretroTranslator::GetDeviceName(baseType), description.c_str());
+            LibretroTranslator::GetDeviceName(baseType).c_str(), description.c_str());
       }
     }
   }

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -452,27 +452,38 @@ bool CInputManager::AccelerometerState(unsigned int port, float& x, float& y, fl
 
 void CInputManager::SetControllerInfo(const retro_controller_info* info)
 {
+  if (info == nullptr)
+    return;
+
   dsyslog("Libretro controller info:");
   dsyslog("------------------------------------------------------------");
 
-  for (unsigned int i = 0; i < info->num_types; i++)
+  for (unsigned int port = 0; info[port].types != nullptr || info[port].num_types != 0; port++)
   {
-    const retro_controller_description& type = info->types[i];
+    if (info[port].types == nullptr || info[port].num_types == 0)
+      continue;
 
-    libretro_device_t baseType = type.id & RETRO_DEVICE_MASK;
+    dsyslog("Port: %u", port);
 
-    std::string description = type.desc ? type.desc : "";
-
-    if (type.id & ~RETRO_DEVICE_MASK)
+    for (unsigned int i = 0; i < info[port].num_types; i++)
     {
-      libretro_subclass_t subclass = (type.id >> RETRO_DEVICE_TYPE_SHIFT) - 1;
-      dsyslog("Device: %s, Subclass: %u, Description: \"%s\"",
-          LibretroTranslator::GetDeviceName(baseType), subclass, description.c_str());
-    }
-    else
-    {
-      dsyslog("Device: %s, Description: \"%s\"",
-          LibretroTranslator::GetDeviceName(baseType), description.c_str());
+      const retro_controller_description& type = info[port].types[i];
+
+      libretro_device_t baseType = type.id & RETRO_DEVICE_MASK;
+
+      std::string description = type.desc ? type.desc : "";
+
+      if (type.id & ~RETRO_DEVICE_MASK)
+      {
+        libretro_subclass_t subclass = (type.id >> RETRO_DEVICE_TYPE_SHIFT) - 1;
+        dsyslog("  Device: %s, Subclass: %u, Description: \"%s\"",
+            LibretroTranslator::GetDeviceName(baseType), subclass, description.c_str());
+      }
+      else
+      {
+        dsyslog("  Device: %s, Description: \"%s\"",
+            LibretroTranslator::GetDeviceName(baseType), description.c_str());
+      }
     }
   }
 

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -109,7 +109,7 @@ libretro_device_t LibretroTranslator::GetDeviceType(const std::string& strLibret
   return RETRO_DEVICE_NONE;
 }
 
-const char* LibretroTranslator::GetDeviceName(libretro_device_t type)
+std::string LibretroTranslator::GetDeviceName(libretro_device_t type)
 {
   switch (type)
   {
@@ -123,7 +123,7 @@ const char* LibretroTranslator::GetDeviceName(libretro_device_t type)
     break;
   }
 
-  return "";
+  return std::to_string(type);
 }
 
 namespace LIBRETRO

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -82,7 +82,7 @@ namespace LIBRETRO
      * \param type The device type to stringify.
      * \return String representation of device type.
      */
-    static const char* GetDeviceName(libretro_device_t type);
+    static std::string GetDeviceName(libretro_device_t type);
 
     /*!
      * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.


### PR DESCRIPTION
## Description

Improves logging input devices.

## How has this been tested?

Tested with Beetle-PSX, which sends device ID = 0 / description = nullptr in the last slot.

Before:

```
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: Libretro controller info:
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: ------------------------------------------------------------
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: Port: 0
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_JOYPAD, Description: "PlayStation Controller"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 1, Description: "DualShock"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 0, Description: "Analog Controller"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 2, Description: "Analog Joystick"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_LIGHTGUN, Subclass: 0, Description: "Guncon / G-Con 45"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_LIGHTGUN, Subclass: 1, Description: "Justifier"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_MOUSE, Subclass: 0, Description: "Mouse"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 3, Description: "neGcon"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 4, Description: "neGcon Rumble"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: , Description: ""
2026-03-16 14:45:16.373 T:19113561   debug <game.libretro.beetle-psx>: ------------------------------------------------------------
```

After:

```
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: Libretro controller info:
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: ------------------------------------------------------------
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>: Port: 0
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_JOYPAD, Description: "PlayStation Controller"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 1, Description: "DualShock"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 0, Description: "Analog Controller"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 2, Description: "Analog Joystick"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_LIGHTGUN, Subclass: 0, Description: "Guncon / G-Con 45"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_LIGHTGUN, Subclass: 1, Description: "Justifier"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_MOUSE, Subclass: 0, Description: "Mouse"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 3, Description: "neGcon"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: RETRO_DEVICE_ANALOG, Subclass: 4, Description: "neGcon Rumble"
2026-03-16 14:45:16.372 T:19113561   debug <game.libretro.beetle-psx>:   Device: 0, Description: ""
2026-03-16 14:45:16.373 T:19113561   debug <game.libretro.beetle-psx>: ------------------------------------------------------------
```