### PR TITLE
Fix setting libretro device types with a device subclass

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -388,7 +388,8 @@ bool CGameLibRetro::ConnectController(bool connect, const std::string& port_addr
   int port = CInputManager::Get().GetPortIndex(strPortAddress);
   if (port < 0)
   {
-    esyslog("Failed to connect controller, invalid port address: %s", strPortAddress.c_str());
+    if (!CInputManager::Get().IsKeyboard(strPortAddress) && !CInputManager::Get().IsMouse(strPortAddress))
+      esyslog("Failed to connect controller, invalid port address: %s", strPortAddress.c_str());
   }
   else
   {

--- a/src/input/ControllerTopology.cpp
+++ b/src/input/ControllerTopology.cpp
@@ -23,14 +23,6 @@ using namespace LIBRETRO;
 
 #define ADDRESS_SEPARATOR  '/'
 
-//! @todo Remove me when these are added to the Game API
-#if !defined(KEYBOARD_PORT_ID)
-#define KEYBOARD_PORT_ID "keyboard"
-#endif
-#if !defined(MOUSE_PORT_ID)
-#define MOUSE_PORT_ID "mouse"
-#endif
-
 CControllerTopology& CControllerTopology::GetInstance()
 {
   static CControllerTopology instance;

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <kodi/addon-instance/Game.h>
+
 // Buttonmap XML
 #define BUTTONMAP_XML_ROOT                  "buttonmap"
 #define BUTTONMAP_XML_ELM_CONTROLLER        "controller"
@@ -32,7 +34,6 @@
 #define TOPOLOGY_XML_ATTR_DEVICE_TYPE       "type"
 #define TOPOLOGY_XML_ATTR_DEVICE_SUBCLASS   "subclass"
 
-// Game API strings
-#define PORT_TYPE_KEYBOARD    "keyboard"
-#define PORT_TYPE_MOUSE       "mouse"
+// Game API strings (KEYBOARD_PORT_ID, MOUSE_PORT_ID, KEYBOARD_PORT_ADDRESS,
+// MOUSE_PORT_ADDRESS are defined in <kodi/addon-instance/Game.h>)
 #define PORT_TYPE_CONTROLLER  "controller"

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -130,7 +130,7 @@ libretro_device_t CInputManager::ConnectController(const std::string &address, c
         if (typeOverride != RETRO_DEVICE_NONE)
           device->SetType(typeOverride);
         if (subclassOverride != RETRO_SUBCLASS_NONE)
-          device->SetSubclass(typeOverride);
+          device->SetSubclass(subclassOverride);
 
         // Calculate type value to send to libretro
         if (device->Subclass() != RETRO_SUBCLASS_NONE)

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -7,6 +7,7 @@
 
 #include "InputManager.h"
 #include "ControllerTopology.h"
+#include "InputDefinitions.h"
 #include "LibretroDevice.h"
 #include "LibretroDeviceInput.h"
 #include "libretro/ClientBridge.h"
@@ -184,6 +185,16 @@ bool CInputManager::GetConnectionPortIndex(const std::string &address, int& conn
 std::string CInputManager::GetAddress(unsigned int port) const
 {
   return CControllerTopology::GetInstance().GetAddress(port);
+}
+
+bool CInputManager::IsKeyboard(const std::string& portAddress) const
+{
+  return portAddress == KEYBOARD_PORT_ADDRESS;
+}
+
+bool CInputManager::IsMouse(const std::string& portAddress) const
+{
+  return portAddress == MOUSE_PORT_ADDRESS;
 }
 
 libretro_device_t CInputManager::GetDeviceType(const std::string &address) const

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -106,6 +106,9 @@ namespace LIBRETRO
 
     std::string GetAddress(unsigned int port) const;
 
+    bool IsKeyboard(const std::string& portAddress) const;
+    bool IsMouse(const std::string& portAddress) const;
+
     /*!
      * \brief Get the libretro device abstraction for the device connected to
      *        the specified address

--- a/src/input/InputTranslator.cpp
+++ b/src/input/InputTranslator.cpp
@@ -12,8 +12,8 @@ using namespace LIBRETRO;
 
 GAME_PORT_TYPE CInputTranslator::GetPortType(const std::string &portType)
 {
-  if (portType == PORT_TYPE_KEYBOARD)    return GAME_PORT_KEYBOARD;
-  if (portType == PORT_TYPE_MOUSE)       return GAME_PORT_MOUSE;
+  if (portType == KEYBOARD_PORT_ID)      return GAME_PORT_KEYBOARD;
+  if (portType == MOUSE_PORT_ID)         return GAME_PORT_MOUSE;
   if (portType == PORT_TYPE_CONTROLLER)  return GAME_PORT_CONTROLLER;
 
   return GAME_PORT_UNKNOWN;


### PR DESCRIPTION
## Description

Was due to a c/p error.

Also improves error logging for keyboard/mouse ports.

## Related PRs

* https://github.com/kodi-game/controller-topology-project/pull/428
* https://github.com/kodi-game/game.libretro/pull/155
* https://github.com/kodi-game/game.libretro.uae/pull/10