### PR TITLE
Game API v5.1.0: Implement "autoconnect" property in topology.xml

### DIFF
--- a/Schema.md
+++ b/Schema.md
@@ -40,7 +40,8 @@ Ports have the following properties:
 
 1. Port type
 2. Port ID (optional for keyboard and mouse)
-3. List of accepted controllers
+3. Optional autoconnect flag (`autoconnect="false"` starts disconnected)
+4. List of accepted controllers
 
 The port type is one of the following:
 

--- a/src/input/ControllerTopology.cpp
+++ b/src/input/ControllerTopology.cpp
@@ -715,7 +715,10 @@ CControllerTopology::PortPtr CControllerTopology::DeserializePort(const TiXmlEle
     const char* strForceConnected = pElement->Attribute(TOPOLOGY_XML_ATTR_FORCE_CONNECTED);
     bool forceConnected = (strForceConnected != nullptr && std::string(strForceConnected) == "true");
 
-    port.reset(new Port{ portType, portId, std::move(connectionPort), forceConnected });
+    const char* strAutoConnect = pElement->Attribute(TOPOLOGY_XML_ATTR_AUTOCONNECT);
+    bool autoConnect = !(strAutoConnect != nullptr && std::string(strAutoConnect) == "false");
+
+    port.reset(new Port{ portType, portId, std::move(connectionPort), forceConnected, autoConnect });
 
     const TiXmlElement* pChild = pElement->FirstChildElement(TOPOLOGY_XML_ELEM_ACCEPTS);
     if (pChild == nullptr)
@@ -799,6 +802,7 @@ game_input_port *CControllerTopology::GetPorts(const std::vector<PortPtr> &portV
       ports[i].type = portVec[i]->type;
       ports[i].port_id = portVec[i]->portId.c_str();
       ports[i].force_connected = portVec[i]->forceConnected;
+      ports[i].autoconnect = portVec[i]->autoConnect;
 
       unsigned int deviceCount = 0;
       ports[i].accepted_devices = GetControllers(portVec[i]->accepts, deviceCount);

--- a/src/input/ControllerTopology.h
+++ b/src/input/ControllerTopology.h
@@ -75,6 +75,7 @@ namespace LIBRETRO
       std::string portId;
       std::string connectionPort; // Empty if no connection port is specified in topology.xml
       bool forceConnected = false;
+      bool autoConnect = true;
       std::vector<ControllerPtr> accepts;
       std::string activeId; // Empty if disconnected
     };

--- a/src/input/InputDefinitions.h
+++ b/src/input/InputDefinitions.h
@@ -30,6 +30,7 @@
 #define TOPOLOGY_XML_ATTR_PORT_ID           "id"
 #define TOPOLOGY_XML_ATTR_CONNECTION_PORT   "connectionPort"
 #define TOPOLOGY_XML_ATTR_FORCE_CONNECTED   "forceConnected"
+#define TOPOLOGY_XML_ATTR_AUTOCONNECT       "autoconnect"
 #define TOPOLOGY_XML_ATTR_CONTROLLER_ID     "controller"
 #define TOPOLOGY_XML_ATTR_DEVICE_TYPE       "type"
 #define TOPOLOGY_XML_ATTR_DEVICE_SUBCLASS   "subclass"


### PR DESCRIPTION
## Description

Companion PR to https://github.com/xbmc/xbmc/pull/28046.

## Related PRs

PRs for full Amiga input support:

* https://github.com/kodi-game/controller-topology-project/pull/428
* https://github.com/kodi-game/game.libretro/pull/155
* https://github.com/xbmc/xbmc/pull/28046
* https://github.com/kodi-game/game.libretro/pull/156
* https://github.com/kodi-game/game.libretro.uae/pull/10
* https://github.com/xbmc/peripheral.joystick/pull/339

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/28046.

Included in latest test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha3-20260317