### PR TITLE
RetroAchievements: Move rc_client ownership into game.libretro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/cheevos/Cheevos.cpp
                      src/cheevos/CheevosEnvironment.cpp
                      src/cheevos/CheevosFrontendBridge.cpp
+                     src/cheevos/CheevosUtils.cpp
                      src/GameInfoLoader.cpp
                      src/input/ButtonMapper.cpp
                      src/input/ControllerLayout.cpp
@@ -58,6 +59,7 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/settings/LibretroSettings.cpp
                      src/settings/Settings.cpp
                      src/settings/SettingsGenerator.cpp
+                     src/utils/Base64.cpp
                      src/utils/Timer.cpp
                      src/video/VideoGeometry.cpp
                      src/video/VideoStream.cpp
@@ -70,6 +72,7 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/audio/SingleFrameAudio.h
                      src/input/ButtonMapper.h
                      src/cheevos/Cheevos.h
+                     src/cheevos/CheevosUtils.h
                      src/input/ControllerLayout.h
                      src/input/ControllerTopology.h
                      src/input/DefaultControllerDefines.h
@@ -100,6 +103,7 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/settings/SettingsGenerator.h
                      src/settings/Settings.h
                      src/settings/SettingsTypes.h
+                     src/utils/Base64.h
                      src/utils/Timer.h
                      src/video/VideoGeometry.h
                      src/video/VideoStream.h

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <cstring>
 #include <future>
-#include <thread>
 #include <vector>
 
 using namespace LIBRETRO;
@@ -38,9 +37,12 @@ namespace
 // rcheevos' own clause as that library documents.
 constexpr const char* RA_CLIENT_NAME = "KodiRetroPlayer";
 constexpr size_t RA_USER_AGENT_CLAUSE_SIZE = 64;
-constexpr int RP_PING_INTERVAL_MS = 120000;
-constexpr int RP_SLEEP_INTERVAL_MS = 100;
+constexpr unsigned int GAME_LOAD_RETRY_MAX_DELAY_SECONDS = 120;
+constexpr unsigned int LOGIN_RETRY_MAX_DELAY_SECONDS = 120;
+constexpr std::chrono::minutes RP_PING_INTERVAL{2};
 constexpr unsigned int RP_BUFFER_SIZE = 512;
+constexpr std::chrono::seconds HTTP_REQUEST_TIMEOUT{30};
+constexpr const char* HTTP_CONNECTION_TIMEOUT_SECONDS = "10";
 constexpr size_t HTTP_READ_CHUNK = 4096;
 
 } // namespace
@@ -145,6 +147,7 @@ void CCheevos::BeginLogin()
   }
 
   m_loginStarted = true;
+  m_loginRetryScheduled = false;
 
   // Begin async login — game load triggered on success
   kodi::Log(ADDON_LOG_INFO, "CCheevos: logging in as '%s'", userName.c_str());
@@ -152,38 +155,39 @@ void CCheevos::BeginLogin()
                                    RcheevosLoginCallback, this);
 }
 
+void CCheevos::BeginGameLoad()
+{
+  if (m_rcClient == nullptr || m_gamePath.empty())
+    return;
+
+  m_gameLoadRetryScheduled = false;
+
+  kodi::Log(ADDON_LOG_INFO, "CCheevos: identifying game: %s", m_gamePath.c_str());
+
+  // rc_hash_generate_from_file() cannot identify a game whose console is not
+  // known up front. Let rc_client try every suitable hashing method instead.
+  rc_client_begin_identify_and_load_game(m_rcClient, RC_CONSOLE_UNKNOWN, m_gamePath.c_str(),
+                                         nullptr, 0, RcheevosGameLoadCallback, this);
+}
+
 void CCheevos::Deinitialize()
 {
-  m_richPresenceRunning = false;
-  if (m_richPresenceThread.joinable())
-    m_richPresenceThread.join();
-
-  // Must happen before rc_client_destroy(): each in-flight request holds a
-  // callback_data pointer owned by the client.
-  //
-  // Requests are moved out before being waited on, never waited on under the
-  // lock: rc_client chains requests from its callbacks, so a completing
-  // request can start another one, and that one needs the same lock. Looping
-  // catches anything started while draining; the shutdown flag stops new
-  // requests reaching the network so the loop terminates.
-  m_shuttingDown = true;
-  for (;;)
+  std::vector<std::future<void>> inFlight;
   {
-    std::vector<std::future<void>> inFlight;
-    {
-      std::lock_guard<std::mutex> lock(m_serverCallsMutex);
-      inFlight.swap(m_serverCalls);
-    }
-
-    if (inFlight.empty())
-      break;
-
-    for (std::future<void>& call : inFlight)
-    {
-      if (call.valid())
-        call.wait();
-    }
+    std::lock_guard<std::mutex> lock(m_serverCallsMutex);
+    m_shuttingDown = true;
+    inFlight.swap(m_serverCalls);
   }
+
+  for (std::future<void>& call : inFlight)
+  {
+    if (call.valid())
+      call.wait();
+  }
+
+  // callback_data belongs to rc_client, so queued responses must be consumed
+  // before the client is destroyed.
+  DispatchServerResponses();
 
   if (m_memoryInitialized)
   {
@@ -197,7 +201,19 @@ void CCheevos::Deinitialize()
     m_rcClient = nullptr;
   }
 
+  {
+    std::lock_guard<std::mutex> lock(m_pendingProgressMutex);
+    m_pendingProgress.clear();
+    m_hasPendingProgress = false;
+  }
+
   m_loginStarted = false;
+  m_loginRetryScheduled = false;
+  m_loginRetryDelaySeconds = 0;
+  m_gameLoadRetryScheduled = false;
+  m_gameLoadRetryDelaySeconds = 0;
+  m_richPresenceActive = false;
+  m_lastProgressSignature.clear();
   m_gameInstance = nullptr;
 }
 
@@ -209,6 +225,9 @@ void CCheevos::SetCredentials(const std::string& username, const std::string& to
     m_loginToken = token;
   }
 
+  m_loginRetryScheduled = false;
+  m_loginRetryDelaySeconds = 0;
+
   // Kodi supplies credentials after the game has been loaded, so this is
   // normally where the login actually starts
   BeginLogin();
@@ -218,6 +237,14 @@ void CCheevos::DoFrame()
 {
   if (m_rcClient == nullptr)
     return;
+
+  DispatchServerResponses();
+
+  if (m_loginRetryScheduled && std::chrono::steady_clock::now() >= m_nextLoginAttempt)
+    BeginLogin();
+
+  if (m_gameLoadRetryScheduled && std::chrono::steady_clock::now() >= m_nextGameLoadAttempt)
+    BeginGameLoad();
 
   rc_client_do_frame(m_rcClient);
 
@@ -234,6 +261,14 @@ void CCheevos::DoFrame()
     m_framesSincePublish = 0;
     PublishAchievementProgress();
   }
+
+  UpdateRichPresence();
+}
+
+void CCheevos::ResetRuntime()
+{
+  if (m_rcClient != nullptr)
+    rc_client_reset(m_rcClient);
 }
 
 void CCheevos::PublishAchievementProgress()
@@ -283,12 +318,9 @@ void CCheevos::PublishAchievementProgress()
   {
     m_lastProgressSignature = signature;
 
-    if (!progress.empty())
-    {
-      kodi::Log(ADDON_LOG_DEBUG, "CCheevos: publishing progress for %zu achievement(s): %s",
-                progress.size(), signature.c_str());
-      m_gameInstance->RCOnAchievementProgress(progress);
-    }
+    kodi::Log(ADDON_LOG_DEBUG, "CCheevos: publishing progress for %zu achievement(s): %s",
+              progress.size(), signature.c_str());
+    m_gameInstance->RCOnAchievementProgress(progress);
   }
 
   rc_client_destroy_achievement_list(achList);
@@ -420,10 +452,7 @@ void CCheevos::RcheevosServerCall(const rc_api_request_t* request,
   CCheevos* const cheevos = static_cast<CCheevos*>(rc_client_get_userdata(client));
 
   std::string userAgent;
-  // rc_client requires the callback to be invoked exactly once. With no
-  // instance to track the request against, or with teardown under way, answer
-  // immediately rather than starting work that would outlive the client.
-  if (cheevos == nullptr || cheevos->m_shuttingDown)
+  if (cheevos == nullptr)
   {
     rc_api_server_response_t resp{};
     resp.http_status_code = HTTP_STATUS_NO_RESPONSE;
@@ -436,65 +465,127 @@ void CCheevos::RcheevosServerCall(const rc_api_request_t* request,
     userAgent = cheevos->m_userAgent;
   }
 
-  auto task = std::async(std::launch::async, [url, postData, userAgent, callback, callback_data]()
+  auto worker = [cheevos, url, postData, userAgent, callback, callback_data]()
   {
     std::string responseData;
     unsigned int statusCode = HTTP_STATUS_NO_RESPONSE;
+    const auto deadline = std::chrono::steady_clock::now() + HTTP_REQUEST_TIMEOUT;
 
-    // Options are set through the curl API rather than the "url|opt=value"
-    // syntax, because the post body is form data full of '&' and '=' which
-    // that syntax would split into further options
-    kodi::vfs::CFile file;
-    if (file.CURLCreate(url))
+    try
     {
-      if (!userAgent.empty())
-        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "User-Agent", userAgent);
-
-      // RetroAchievements reports failures as a JSON body with a 4xx status,
-      // and rc_client needs that body to explain the failure
-      file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
-
-      // Kodi base64-decodes this option, so it has to be encoded here
-      if (!postData.empty())
-        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "postdata", Base64Encode(postData));
-
-      if (file.CURLOpen(ADDON_READ_NO_CACHE))
+      // Options are set through the curl API rather than the "url|opt=value"
+      // syntax, because the post body is form data full of '&' and '=' which
+      // that syntax would split into further options
+      kodi::vfs::CFile file;
+      if (file.CURLCreate(url))
       {
-        char buffer[HTTP_READ_CHUNK];
-        ssize_t bytesRead;
-        while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
-          responseData.append(buffer, static_cast<size_t>(bytesRead));
+        if (!userAgent.empty())
+          file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "User-Agent", userAgent);
 
-        statusCode = ParseHttpStatus(
-            file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, ""));
+        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "connection-timeout",
+                           HTTP_CONNECTION_TIMEOUT_SECONDS);
 
-        file.Close();
+        // RetroAchievements reports failures as a JSON body with a 4xx status,
+        // and rc_client needs that body to explain the failure
+        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
+
+        // Kodi base64-decodes this option, so it has to be encoded here
+        if (!postData.empty())
+          file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "postdata", Base64Encode(postData));
+
+        if (file.CURLOpen(ADDON_READ_NO_CACHE | ADDON_READ_TRUNCATED))
+        {
+          char buffer[HTTP_READ_CHUNK];
+          ssize_t bytesRead;
+          while (!cheevos->m_shuttingDown && std::chrono::steady_clock::now() < deadline &&
+                 (bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
+            responseData.append(buffer, static_cast<size_t>(bytesRead));
+
+          if (!cheevos->m_shuttingDown && std::chrono::steady_clock::now() < deadline)
+          {
+            statusCode = ParseHttpStatus(
+                file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, ""));
+          }
+          else
+          {
+            responseData.clear();
+          }
+
+          file.Close();
+        }
       }
+    }
+    catch (...)
+    {
+      responseData.clear();
     }
 
     if (statusCode == HTTP_STATUS_NO_RESPONSE)
       kodi::Log(ADDON_LOG_ERROR, "CCheevos: request failed: %s", url.c_str());
 
-    rc_api_server_response_t resp{};
-    resp.body = responseData.c_str();
-    resp.body_length = responseData.size();
-    resp.http_status_code = static_cast<int>(statusCode);
+    cheevos->QueueServerResponse(callback, callback_data, std::move(responseData),
+                                 static_cast<int>(statusCode));
+  };
 
-    callback(&resp, callback_data);
-  });
-
-  // Tracked rather than detached: rc_client owns callback_data, so a request
-  // outliving rc_client_destroy() would invoke the callback against freed
-  // memory. Deinitialize() waits for everything held here first.
   {
     std::lock_guard<std::mutex> lock(cheevos->m_serverCallsMutex);
+
+    if (cheevos->m_shuttingDown)
+    {
+      cheevos->m_serverResponses.push_back(
+          {callback, callback_data, {}, HTTP_STATUS_NO_RESPONSE});
+      return;
+    }
 
     std::erase_if(cheevos->m_serverCalls, [](const std::future<void>& call)
                   { return call.wait_for(std::chrono::seconds(0)) == std::future_status::ready; });
 
-    cheevos->m_serverCalls.emplace_back(std::move(task));
+    try
+    {
+      cheevos->m_serverCalls.reserve(cheevos->m_serverCalls.size() + 1);
+      cheevos->m_serverCalls.emplace_back(std::async(std::launch::async, std::move(worker)));
+    }
+    catch (...)
+    {
+      cheevos->m_serverResponses.push_back(
+          {callback, callback_data, {}, HTTP_STATUS_NO_RESPONSE});
+    }
   }
 }
+
+void CCheevos::QueueServerResponse(rc_client_server_callback_t callback,
+                                   void* callbackData,
+                                   std::string body,
+                                   int statusCode)
+{
+  std::lock_guard<std::mutex> lock(m_serverCallsMutex);
+  m_serverResponses.push_back({callback, callbackData, std::move(body), statusCode});
+}
+
+void CCheevos::DispatchServerResponses()
+{
+  for (;;)
+  {
+    std::vector<ServerResponse> responses;
+    {
+      std::lock_guard<std::mutex> lock(m_serverCallsMutex);
+      responses.swap(m_serverResponses);
+    }
+
+    if (responses.empty())
+      return;
+
+    for (ServerResponse& completed : responses)
+    {
+      rc_api_server_response_t response{};
+      response.body = completed.body.c_str();
+      response.body_length = completed.body.size();
+      response.http_status_code = completed.statusCode;
+      completed.callback(&response, completed.callbackData);
+    }
+  }
+}
+
 // Memory read callback
 uint32_t CCheevos::RcheevosReadMemory(uint32_t address, uint8_t* buffer,
                                        uint32_t num_bytes, rc_client_t* client)
@@ -652,10 +743,7 @@ void CCheevos::RcheevosLoginCallback(int result, const char* errorMessage,
     kodi::Log(ADDON_LOG_ERROR, "CCheevos: login failed: %s",
               errorMessage != nullptr ? errorMessage : "unknown error");
 
-    // Let the next credentials try again. This guard exists to stop a second
-    // login racing one already in flight, not to make failure permanent --
-    // left set, a corrected username or token could not start a login until
-    // the game was unloaded.
+    // Allow corrected credentials or a scheduled retry to start another login.
     cheevos->m_loginStarted = false;
 
     game_rc_login_result data{};
@@ -668,9 +756,30 @@ void CCheevos::RcheevosLoginCallback(int result, const char* errorMessage,
     data.credentials_rejected = (result == RC_INVALID_CREDENTIALS ||
                                  result == RC_EXPIRED_TOKEN || result == RC_ACCESS_DENIED);
 
+    if (data.credentials_rejected)
+    {
+      cheevos->m_loginRetryScheduled = false;
+      cheevos->m_loginRetryDelaySeconds = 0;
+    }
+    else
+    {
+      if (cheevos->m_loginRetryDelaySeconds == 0)
+        cheevos->m_loginRetryDelaySeconds = 1;
+      else
+        cheevos->m_loginRetryDelaySeconds =
+            std::min(cheevos->m_loginRetryDelaySeconds * 2, LOGIN_RETRY_MAX_DELAY_SECONDS);
+
+      cheevos->m_nextLoginAttempt = std::chrono::steady_clock::now() +
+                                    std::chrono::seconds(cheevos->m_loginRetryDelaySeconds);
+      cheevos->m_loginRetryScheduled = true;
+    }
+
     cheevos->m_gameInstance->RCOnLoginResult(data);
     return;
   }
+
+  cheevos->m_loginRetryScheduled = false;
+  cheevos->m_loginRetryDelaySeconds = 0;
 
   const rc_client_user_t* user = rc_client_get_user_info(client);
   if (user != nullptr)
@@ -693,20 +802,7 @@ void CCheevos::RcheevosLoginCallback(int result, const char* errorMessage,
               user->username != nullptr ? user->username : "", user->score);
   }
 
-  // Now identify and load the game
-  if (!cheevos->m_gamePath.empty())
-  {
-    kodi::Log(ADDON_LOG_INFO, "CCheevos: identifying game: %s", cheevos->m_gamePath.c_str());
-
-    // rc_hash_generate_from_file() rejects RC_CONSOLE_UNKNOWN: its console
-    // switch has no case for it and the default arm returns an error, so it
-    // cannot identify a game whose console isn't known up front. Let rc_client
-    // do the identification instead, which tries every hashing method that
-    // suits the file rather than requiring the console to be named.
-    rc_client_begin_identify_and_load_game(client, RC_CONSOLE_UNKNOWN,
-                                           cheevos->m_gamePath.c_str(), nullptr, 0,
-                                           RcheevosGameLoadCallback, cheevos);
-  }
+  cheevos->BeginGameLoad();
 }
 
 // Game load callback
@@ -717,12 +813,48 @@ void CCheevos::RcheevosGameLoadCallback(int result, const char* errorMessage,
   if (cheevos == nullptr || cheevos->m_gameInstance == nullptr)
     return;
 
+  if (result == RC_NO_GAME_LOADED)
+  {
+    cheevos->m_gameLoadRetryScheduled = false;
+    cheevos->m_gameLoadRetryDelaySeconds = 0;
+
+    game_rc_game_loaded empty{};
+    cheevos->m_gameInstance->RCOnGameLoaded(empty);
+    return;
+  }
+
   if (result != RC_OK)
   {
     kodi::Log(ADDON_LOG_ERROR, "CCheevos: game load failed: %s",
               errorMessage != nullptr ? errorMessage : "unknown error");
+
+    if (result == RC_NO_RESPONSE || result == RC_API_FAILURE || result == RC_INVALID_JSON)
+    {
+      if (cheevos->m_gameLoadRetryDelaySeconds == 0)
+        cheevos->m_gameLoadRetryDelaySeconds = 1;
+      else
+        cheevos->m_gameLoadRetryDelaySeconds = std::min(
+            cheevos->m_gameLoadRetryDelaySeconds * 2, GAME_LOAD_RETRY_MAX_DELAY_SECONDS);
+
+      cheevos->m_nextGameLoadAttempt =
+          std::chrono::steady_clock::now() +
+          std::chrono::seconds(cheevos->m_gameLoadRetryDelaySeconds);
+      cheevos->m_gameLoadRetryScheduled = true;
+    }
+    else if (result != RC_ABORTED)
+    {
+      cheevos->m_gameLoadRetryScheduled = false;
+      cheevos->m_gameLoadRetryDelaySeconds = 0;
+
+      game_rc_game_loaded empty{};
+      cheevos->m_gameInstance->RCOnGameLoaded(empty);
+    }
+
     return;
   }
+
+  cheevos->m_gameLoadRetryScheduled = false;
+  cheevos->m_gameLoadRetryDelaySeconds = 0;
 
   const rc_client_game_t* gameInfo = rc_client_get_game_info(client);
 
@@ -739,6 +871,8 @@ void CCheevos::RcheevosGameLoadCallback(int result, const char* errorMessage,
   {
     kodi::Log(ADDON_LOG_INFO, "CCheevos: '%s' - this ROM version has no achievements",
               gameInfo->title);
+
+    rc_client_unload_game(client);
 
     game_rc_game_loaded empty{};
     cheevos->m_gameInstance->RCOnGameLoaded(empty);
@@ -803,27 +937,25 @@ void CCheevos::RcheevosGameLoadCallback(int result, const char* errorMessage,
 
   cheevos->ApplyPendingProgress();
 
-  // Start rich presence ping thread
-  cheevos->m_richPresenceRunning = true;
-  cheevos->m_richPresenceThread = std::thread(&CCheevos::RichPresencePingThread, cheevos);
+  cheevos->m_richPresenceActive = true;
+  cheevos->m_nextRichPresencePing = std::chrono::steady_clock::now();
 }
 
-// Rich presence ping thread
-void CCheevos::RichPresencePingThread()
+void CCheevos::UpdateRichPresence()
 {
-  while (m_richPresenceRunning)
-  {
-    if (m_rcClient != nullptr && m_gameInstance != nullptr)
-    {
-      char buffer[RP_BUFFER_SIZE]{};
-      rc_client_get_rich_presence_message(m_rcClient, buffer, sizeof(buffer));
-      const std::string rpMessage(buffer);
+  if (!m_richPresenceActive || m_rcClient == nullptr || m_gameInstance == nullptr)
+    return;
 
-      if (!rpMessage.empty())
-        m_gameInstance->RCOnRichPresenceUpdated(rpMessage.c_str());
-    }
+  const auto now = std::chrono::steady_clock::now();
+  if (now < m_nextRichPresencePing)
+    return;
 
-    for (int i = 0; i < (RP_PING_INTERVAL_MS / RP_SLEEP_INTERVAL_MS) && m_richPresenceRunning; ++i)
-      std::this_thread::sleep_for(std::chrono::milliseconds(RP_SLEEP_INTERVAL_MS));
-  }
+  m_nextRichPresencePing = now + RP_PING_INTERVAL;
+
+  char buffer[RP_BUFFER_SIZE]{};
+  rc_client_get_rich_presence_message(m_rcClient, buffer, sizeof(buffer));
+  const std::string rpMessage(buffer);
+
+  if (!rpMessage.empty())
+    m_gameInstance->RCOnRichPresenceUpdated(rpMessage.c_str());
 }

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -1,7 +1,5 @@
 /*
- *  This file is based on https://github.com/libretro/RetroArch/blob/96c5f5dfb07454c972c50838815330382d6b1911/cheevos/fixup.c
- *
- *  Copyright (C) 2014-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.
@@ -9,421 +7,823 @@
 
 #include "Cheevos.h"
 
+#include "CheevosUtils.h"
 #include "libretro/LibretroEnvironment.h"
 #include "libretro/MemoryMap.h"
-#include "rcheevos/rc_api_request.h"
-#include "rcheevos/rc_api_runtime.h"
-#include "rcheevos/rc_consoles.h"
-#include "rcheevos/rc_hash.h"
+#include "utils/Base64.h"
 
+#include <kodi/Filesystem.h>
+#include <kodi/General.h>
+#include <kodi/Network.h>
+#include <kodi/addon-instance/Game.h>
+#include <kodi/c-api/addon-instance/game.h>
+
+#include <rcheevos/rc_api_runtime.h>
+#include <rcheevos/rc_client.h>
+#include <rcheevos/rc_libretro.h>
+
+#include <algorithm>
+#include <chrono>
 #include <cstring>
-#include <limits>
+#include <future>
+#include <thread>
+#include <vector>
 
 using namespace LIBRETRO;
 
 namespace
 {
-constexpr unsigned int HASH_SIZE = 33;
-constexpr unsigned int RICH_PRESENCE_EVAL_SIZE = 512;
-constexpr unsigned int URL_SIZE = 512;
+// RetroAchievements identifies the client by User-Agent, so it has to name
+// this add-on and its version rather than a hardcoded string, and carry
+// rcheevos' own clause as that library documents.
+constexpr const char* RA_CLIENT_NAME = "KodiRetroPlayer";
+constexpr size_t RA_USER_AGENT_CLAUSE_SIZE = 64;
+constexpr int RP_PING_INTERVAL_MS = 120000;
+constexpr int RP_SLEEP_INTERVAL_MS = 100;
+constexpr unsigned int RP_BUFFER_SIZE = 512;
+constexpr size_t HTTP_READ_CHUNK = 4096;
+
 } // namespace
 
-CCheevos::CCheevos()
+// rc_libretro's get_core_memory_info callback takes neither a client nor a
+// userdata pointer, so it alone has no way to be handed the instance. It is
+// only ever called from inside rc_libretro_memory_init(), which we call
+// ourselves, so the pointer is set around that call and cleared after rather
+// than being left set for the life of the add-on. Every rc_client callback
+// carries rc_client_t* and reads the instance back with
+// rc_client_get_userdata() instead.
+static CCheevos* s_memoryInfoInstance = nullptr;
+
+CCheevos::CCheevos() = default;
+
+CCheevos& CCheevos::Get()
 {
-  rc_runtime_init(&m_runtime);
+  static CCheevos instance;
+  return instance;
 }
 
-void CCheevos::Initialize()
+void CCheevos::Initialize(kodi::addon::CInstanceGame* gameInstance,
+                          const std::string& gamePath,
+                          MemoryAccessCallback memoryCallback)
 {
-  rc_runtime_init(&m_runtime);
+  Deinitialize();
+
+  // Deinitialize() latches the shutdown flag to drain in-flight requests, and
+  // loading a new game runs through it first. Clearing it here is what lets
+  // requests reach the network again.
+  m_shuttingDown = false;
+
+  m_gameInstance = gameInstance;
+  m_gamePath = gamePath;
+  m_memoryCallback = std::move(memoryCallback);
+
+  // Create rc_client
+  m_rcClient = rc_client_create(RcheevosReadMemory, RcheevosServerCall);
+  if (m_rcClient == nullptr)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "CCheevos: failed to create rc_client");
+    return;
+  }
+
+  // rc_client's callbacks take no userdata parameter of their own, but they
+  // all receive the client, and the client will carry one for us
+  rc_client_set_userdata(m_rcClient, this);
+
+  rc_client_set_event_handler(m_rcClient, RcheevosEventHandler);
+  rc_client_set_hardcore_enabled(m_rcClient, 0);
+
+  {
+    char clause[RA_USER_AGENT_CLAUSE_SIZE]{};
+    rc_client_get_user_agent_clause(m_rcClient, clause, sizeof(clause));
+
+    // RetroAchievements identifies the integration by the leading client
+    // name and version, so those stay ours. Everything after describes the
+    // host, and that comes from Kodi rather than being assembled here, so it
+    // stays right when Kodi's own reporting changes.
+    std::string userAgent = std::string(RA_CLIENT_NAME) + "/" + kodi::addon::GetAddonInfo("version");
+
+    const std::string kodiUserAgent = kodi::network::GetUserAgent();
+    if (!kodiUserAgent.empty())
+      userAgent += " (" + kodiUserAgent + ")";
+
+    if (clause[0] != '\0')
+      userAgent += " " + std::string(clause);
+
+    std::lock_guard<std::mutex> lock(m_userAgentMutex);
+    m_userAgent = std::move(userAgent);
+    kodi::Log(ADDON_LOG_DEBUG, "CCheevos: user agent '%s'", m_userAgent.c_str());
+  }
+
+  // Enable verbose logging
+  rc_client_enable_logging(m_rcClient, RC_CLIENT_LOG_LEVEL_VERBOSE,
+    [](const char* message, const rc_client_t*) {
+      kodi::Log(ADDON_LOG_DEBUG, "rc_client: %s", message);
+    });
+
+  // The frontend may not have supplied credentials yet, in which case
+  // SetCredentials() starts the login when they arrive
+  BeginLogin();
+}
+
+void CCheevos::BeginLogin()
+{
+  if (m_rcClient == nullptr || m_loginStarted)
+    return;
+
+  std::string userName;
+  std::string loginToken;
+  {
+    std::lock_guard<std::mutex> lock(m_credentialsMutex);
+    userName = m_userName;
+    loginToken = m_loginToken;
+  }
+
+  if (userName.empty() || loginToken.empty())
+  {
+    kodi::Log(ADDON_LOG_INFO, "CCheevos: no RA credentials yet, deferring login");
+    return;
+  }
+
+  m_loginStarted = true;
+
+  // Begin async login — game load triggered on success
+  kodi::Log(ADDON_LOG_INFO, "CCheevos: logging in as '%s'", userName.c_str());
+  rc_client_begin_login_with_token(m_rcClient, userName.c_str(), loginToken.c_str(),
+                                   RcheevosLoginCallback, this);
 }
 
 void CCheevos::Deinitialize()
 {
-  rc_runtime_destroy(&m_runtime);
-}
+  m_richPresenceRunning = false;
+  if (m_richPresenceThread.joinable())
+    m_richPresenceThread.join();
 
-void CCheevos::ResetRuntime()
-{
-  rc_runtime_reset(&m_runtime);
-  m_richPresence =
-      rc_parse_richpresence(m_richPresenceBuffer.data(), m_richPresenceScript.c_str(), NULL, 0);
-}
-
-CCheevos& CCheevos::Get(void)
-{
-  static CCheevos _instance;
-  return _instance;
-}
-
-bool CCheevos::GenerateHashFromFile(std::string& hash,
-                                    unsigned int consoleID,
-                                    const std::string& filePath)
-{
-  char _hash[HASH_SIZE] = {};
-
-  if (consoleID > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+  // Must happen before rc_client_destroy(): each in-flight request holds a
+  // callback_data pointer owned by the client.
+  //
+  // Requests are moved out before being waited on, never waited on under the
+  // lock: rc_client chains requests from its callbacks, so a completing
+  // request can start another one, and that one needs the same lock. Looping
+  // catches anything started while draining; the shutdown flag stops new
+  // requests reaching the network so the loop terminates.
+  m_shuttingDown = true;
+  for (;;)
   {
-    hash.clear();
-    m_hash.clear();
-    return false;
-  }
-
-  const int raConsoleID = static_cast<int>(consoleID);
-  int res = rc_hash_generate_from_file(_hash, raConsoleID, filePath.c_str());
-  const bool success = (res != 0);
-
-  hash = _hash;
-  if (success)
-  {
-    m_addressFixups.clear();
-    m_hash = hash;
-    m_consoleID = consoleID;
-  }
-  else
-  {
-    hash.clear();
-    m_hash.clear();
-  }
-
-  return success;
-}
-
-bool CCheevos::GetGameIDUrl(std::string& url, const std::string& hash)
-{
-  url.clear();
-
-  rc_api_resolve_hash_request_t params{};
-  params.game_hash = hash.c_str();
-
-  rc_api_request_t request{};
-  const int res = rc_api_init_resolve_hash_request(&request, &params);
-  if (res == RC_OK && request.url != nullptr)
-  {
-    url = request.url;
-    if (request.post_data != nullptr)
+    std::vector<std::future<void>> inFlight;
     {
-      if (url.find('?') != std::string::npos)
-        url += std::string("&") + request.post_data;
-      else
-        url += std::string("?") + request.post_data;
+      std::lock_guard<std::mutex> lock(m_serverCallsMutex);
+      inFlight.swap(m_serverCalls);
+    }
+
+    if (inFlight.empty())
+      break;
+
+    for (std::future<void>& call : inFlight)
+    {
+      if (call.valid())
+        call.wait();
     }
   }
-  rc_api_destroy_request(&request);
 
-  return res == RC_OK && !url.empty();
-}
-
-bool CCheevos::GetPatchFileUrl(std::string& url,
-                               const std::string& username,
-                               const std::string& token,
-                               unsigned int gameID)
-{
-  url.clear();
-
-  rc_api_fetch_game_data_request_t params{};
-  params.username = username.c_str();
-  params.api_token = token.c_str();
-  params.game_id = gameID;
-
-  rc_api_request_t request{};
-  const int res = rc_api_init_fetch_game_data_request(&request, &params);
-  if (res == RC_OK && request.url != nullptr)
+  if (m_memoryInitialized)
   {
-    url = request.url;
-    if (request.post_data != nullptr)
-    {
-      if (url.find('?') != std::string::npos)
-        url += std::string("&") + request.post_data;
-      else
-        url += std::string("?") + request.post_data;
-    }
+    rc_libretro_memory_destroy(&m_memoryRegions);
+    m_memoryInitialized = false;
   }
-  rc_api_destroy_request(&request);
 
-  return res == RC_OK && !url.empty();
-}
-
-void CCheevos::SetRetroAchievementsCredentials(const std::string& username, const std::string& token)
-{
-  m_username = username;
-  m_token = token;
-}
-
-bool CCheevos::PostRichPresenceUrl(std::string& url,
-                                   std::string& postData,
-                                   const std::string& username,
-                                   const std::string& token,
-                                   unsigned int gameID,
-                                   const std::string& richPresence)
-{
-  url.clear();
-  postData.clear();
-
-  rc_api_ping_request_t params{};
-  params.username = username.c_str();
-  params.api_token = token.c_str();
-  params.game_id = gameID;
-  params.rich_presence = richPresence.c_str();
-
-  rc_api_request_t request{};
-  const int res = rc_api_init_ping_request(&request, &params);
-  if (res == RC_OK && request.url != nullptr)
+  if (m_rcClient != nullptr)
   {
-    url = request.url;
-    postData = request.post_data != nullptr ? request.post_data : "";
+    rc_client_destroy(m_rcClient);
+    m_rcClient = nullptr;
   }
-  rc_api_destroy_request(&request);
 
-  return res == RC_OK && !url.empty();
+  m_loginStarted = false;
+  m_gameInstance = nullptr;
 }
 
-void CCheevos::EnableRichPresence(const std::string& script)
+void CCheevos::SetCredentials(const std::string& username, const std::string& token)
 {
-  const char* _script = script.c_str();
-
-  rc_runtime_activate_richpresence(&m_runtime, _script, NULL, 0);
-
-  m_richPresenceBuffer.resize(rc_richpresence_size(_script));
-
-  m_richPresence = rc_parse_richpresence(m_richPresenceBuffer.data(), _script, NULL, 0);
-
-  m_richPresenceScript = script;
-}
-
-void CCheevos::EvaluateRichPresence(std::string& evaluation, unsigned int consoleID)
-{
-  char _evaluation[RICH_PRESENCE_EVAL_SIZE] = {};
-
-  m_consoleID = consoleID;
-  rc_evaluate_richpresence(m_richPresence, _evaluation, RICH_PRESENCE_EVAL_SIZE, PeekInternal, this,
-                           NULL);
-  evaluation = _evaluation;
-}
-
-bool CCheevos::ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression)
-{
-  // Returns 0 when the achievement is activated successfully
-  return rc_runtime_activate_achievement(&m_runtime, cheevo_id, memAddrExpression.c_str(), NULL,
-                                         0) == 0;
-}
-
-bool CCheevos::AwardAchievement(
-    char* url, size_t size, unsigned cheevo_id, int hardcore, const std::string& game_hash)
-{
-  if (url == nullptr || size == 0)
-    return false;
-
-  url[0] = '\0';
-
-  rc_api_award_achievement_request_t params{};
-  params.username = m_username.c_str();
-  params.api_token = m_token.c_str();
-  params.achievement_id = cheevo_id;
-  params.hardcore = hardcore;
-  params.game_hash = game_hash.c_str();
-
-  rc_api_request_t request{};
-  const int res = rc_api_init_award_achievement_request(&request, &params);
-  if (res == RC_OK && request.url != nullptr)
   {
-    std::string fullUrl = request.url;
-    if (request.post_data != nullptr)
-    {
-      if (fullUrl.find('?') != std::string::npos)
-        fullUrl += std::string("&") + request.post_data;
-      else
-        fullUrl += std::string("?") + request.post_data;
-    }
-    std::strncpy(url, fullUrl.c_str(), size - 1);
-    url[size - 1] = '\0';
+    std::lock_guard<std::mutex> lock(m_credentialsMutex);
+    m_userName = username;
+    m_loginToken = token;
   }
-  rc_api_destroy_request(&request);
 
-  return res == RC_OK && url[0] != '\0';
+  // Kodi supplies credentials after the game has been loaded, so this is
+  // normally where the login actually starts
+  BeginLogin();
 }
 
-void CCheevos::GetCheevoUrlId(const std::function<void(const std::string& achievementUrl,
-                                                       unsigned int cheevoId)>& callback)
+void CCheevos::DoFrame()
 {
-  m_callback = callback;
-}
-
-void CCheevos::DeactivateTriggeredAchievement(unsigned cheevo_id)
-{
-  rc_runtime_deactivate_achievement(&m_runtime, cheevo_id);
-
-  if (m_hash.empty() || !m_callback)
+  if (m_rcClient == nullptr)
     return;
 
-  char url[URL_SIZE] = {};
-  if (AwardAchievement(url, URL_SIZE, cheevo_id, 0, m_hash))
-    m_callback(url, cheevo_id);
-}
+  rc_client_do_frame(m_rcClient);
 
-void CCheevos::RuntimeEventHandler(const rc_runtime_event_t* runtime_event)
-{
-  if (runtime_event->type == RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED)
+  // Progress is read from the achievement list rather than driven by
+  // rc_client's progress-indicator events. Those fire only for the single
+  // achievement rc_client considers most relevant, and only for as long as an
+  // on-screen indicator would be showing, so most measured achievements never
+  // produce one and their progress would never reach the frontend.
+  //
+  // The list is only rebuilt once a second, and nothing is sent unless a value
+  // actually changed, so this costs little per frame.
+  if (++m_framesSincePublish >= PROGRESS_PUBLISH_INTERVAL_FRAMES)
   {
-    CCheevos::Get().DeactivateTriggeredAchievement(runtime_event->id);
+    m_framesSincePublish = 0;
+    PublishAchievementProgress();
   }
 }
 
-void CCheevos::TestCheevoStatusPerFrame()
+void CCheevos::PublishAchievementProgress()
 {
-  rc_runtime_do_frame(&m_runtime, &RuntimeEventHandler, PeekInternal, this, NULL);
-}
+  if (m_rcClient == nullptr || m_gameInstance == nullptr)
+    return;
 
-unsigned int CCheevos::PeekInternal(unsigned address, unsigned num_bytes, void* ud)
-{
-  CCheevos* cheevos = static_cast<CCheevos*>(ud);
-  if (cheevos != nullptr)
-    return cheevos->Peek(address, num_bytes);
+  // String pointers reference rc_client-owned memory, valid until the list is
+  // destroyed, so the callback has to happen before that
+  rc_client_achievement_list_t* achList = rc_client_create_achievement_list(
+      m_rcClient, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+      RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+  if (achList == nullptr)
+    return;
 
-  return 0;
-}
+  std::vector<game_rc_achievement_progress> progress;
+  std::string signature;
 
-unsigned int CCheevos::Peek(unsigned int address, unsigned int numBytes)
-{
-  CMemoryMap mmap = CLibretroEnvironment::Get().GetMemoryMap();
-
-  const uint8_t* data = FixupFind(address, mmap, m_consoleID);
-  unsigned value = 0;
-
-  if (data)
+  for (uint32_t b = 0; b < achList->num_buckets; ++b)
   {
-    switch (numBytes)
+    const auto& bucket = achList->buckets[b];
+    for (uint32_t a = 0; a < bucket.num_achievements; ++a)
     {
-      case 4:
-        value |= data[2] << 16 | data[3] << 24;
-        //no break
-      case 2:
-        value |= data[1] << 8;
-        //no break
-      case 1:
-        value |= data[0];
-        //no break
-      default:
-        break;
+      const rc_client_achievement_t* ach = bucket.achievements[a];
+
+      // Achievements without a counting trigger report an empty string here,
+      // and there is nothing to draw a bar from
+      if (ach->measured_progress[0] == '\0')
+        continue;
+
+      game_rc_achievement_progress entry{};
+      entry.id = ach->id;
+      entry.measured_percent = ach->measured_percent;
+      entry.measured_progress = ach->measured_progress;
+      progress.push_back(entry);
+
+      signature += std::to_string(ach->id);
+      signature += '=';
+      signature += ach->measured_progress;
+      signature += ';';
     }
   }
 
-  return value;
-}
-
-const uint8_t* CCheevos::FixupFind(unsigned address, CMemoryMap& mmap, unsigned int consoleID)
-{
-  auto location = m_addressFixups.find(address);
-  if (location != m_addressFixups.end())
-    return location->second;
-
-  const uint8_t* dataAddress = PatchAddress(address, mmap, consoleID);
-  m_addressFixups[address] = dataAddress;
-
-  return dataAddress;
-}
-
-const uint8_t* CCheevos::PatchAddress(size_t address, CMemoryMap& mmap, unsigned int consoleID)
-{
-  const void* pointer = NULL;
-  size_t original_address = address;
-
-  switch (consoleID)
+  // Called once a second, so skip the crossing into Kodi unless something the
+  // frontend would draw has actually changed
+  if (signature != m_lastProgressSignature)
   {
-    case RC_CONSOLE_NINTENDO:
-      if (address >= 0x0800 && address < 0x2000)
-        address &= 0x07ff;
-      break;
-    case RC_CONSOLE_GAMEBOY_COLOR:
-      if (address >= 0xe000 && address <= 0xfdff)
-        address -= 0x2000;
-      break;
-    default:
-      break;
+    m_lastProgressSignature = signature;
+
+    if (!progress.empty())
+    {
+      kodi::Log(ADDON_LOG_DEBUG, "CCheevos: publishing progress for %zu achievement(s): %s",
+                progress.size(), signature.c_str());
+      m_gameInstance->RCOnAchievementProgress(progress);
+    }
   }
 
-  if (mmap.Size() != 0)
-  {
-    switch (consoleID)
-    {
-      case RC_CONSOLE_GAMEBOY_ADVANCE:
-        if (address < 0x8000)
-          address += 0x3000000;
-        else
-          address += 0x2000000 - 0x8000;
-        break;
-      case RC_CONSOLE_PC_ENGINE:
-        if (address < 0x002000)
-          address += 0x1f0000;
-        else if (address < 0x012000)
-          address += 0x100000 - 0x002000;
-        else if (address < 0x042000)
-          address += 0x0d0000 - 0x012000;
-        else
-          address += 0x1ee000 - 0x042000;
-        break;
-      case RC_CONSOLE_SUPER_NINTENDO:
-        if (address < 0x020000)
-          address += 0x7e0000;
-        else
-          address += 0x006000 - 0x020000;
-        break;
-      case RC_CONSOLE_SEGA_CD:
-        if (address < 0x010000)
-          address += 0xFF0000;
-        else
-          address += 0x80020000 - 0x010000;
-        break;
-      default:
-        break;
-    }
+  rc_client_destroy_achievement_list(achList);
+}
 
-    for (size_t i = 0; i < mmap.Size(); i++)
+void CCheevos::ApplyPendingProgress()
+{
+  std::vector<uint8_t> progress;
+
+  {
+    std::lock_guard<std::mutex> lock(m_pendingProgressMutex);
+    if (!m_hasPendingProgress)
+      return;
+
+    progress = std::move(m_pendingProgress);
+    m_pendingProgress.clear();
+    m_hasPendingProgress = false;
+  }
+
+  if (m_rcClient == nullptr || !rc_client_is_game_loaded(m_rcClient))
+    return;
+
+  const int result = progress.empty()
+                         ? rc_client_deserialize_progress_sized(m_rcClient, nullptr, 0)
+                         : rc_client_deserialize_progress_sized(m_rcClient, progress.data(),
+                                                                progress.size());
+
+  if (result == RC_OK)
+    kodi::Log(ADDON_LOG_INFO, "CCheevos: applied %zu bytes of held progress", progress.size());
+  else
+    kodi::Log(ADDON_LOG_ERROR, "CCheevos: held progress refused (%d)", result);
+}
+
+size_t CCheevos::ProgressSize()
+{
+  // rc_client_progress_size() asserts if no game is loaded, and there is
+  // nothing worth saving in that case anyway
+  if (m_rcClient == nullptr || !rc_client_is_game_loaded(m_rcClient))
+    return 0;
+
+  return rc_client_progress_size(m_rcClient);
+}
+
+size_t CCheevos::SerializeProgress(uint8_t* buffer, size_t size)
+{
+  if (buffer == nullptr || size == 0)
+    return 0;
+
+  if (m_rcClient == nullptr || !rc_client_is_game_loaded(m_rcClient))
+    return 0;
+
+  const size_t required = rc_client_progress_size(m_rcClient);
+  if (required == 0)
+    return 0;
+
+  if (required > size)
+  {
+    // Warned once per game so the reserved size can be revisited rather than
+    // silently dropping progress from every savestate
+    if (!m_progressTooLargeWarned)
     {
-      const retro_memory_descriptor_kodi& desc = mmap[i];
-      if (((desc.descriptor.start ^ address) & desc.descriptor.select) == 0)
+      m_progressTooLargeWarned = true;
+      kodi::Log(ADDON_LOG_WARNING,
+                "CCheevos: achievement progress needs %zu bytes but only %zu are reserved in the "
+                "savestate; progress will not be saved for this game",
+                required, size);
+    }
+    return 0;
+  }
+
+  // The _sized() variant is bounded, so a runtime that grew since the size was
+  // queried truncates cleanly instead of running off the end of the buffer
+  if (rc_client_serialize_progress_sized(m_rcClient, buffer, size) != RC_OK)
+    return 0;
+
+  return required;
+}
+
+bool CCheevos::DeserializeProgress(const uint8_t* buffer, size_t size)
+{
+  if (m_rcClient == nullptr)
+    return false;
+
+  if (!rc_client_is_game_loaded(m_rcClient))
+  {
+    // The frontend restores a savestate as part of loading it, which is before
+    // the game has been identified here: signing in and identifying are both
+    // round trips to the server and are still in flight at this point. Hold
+    // what we were given and apply it when the game arrives -- dropping it is
+    // why restoring progress never took effect.
+    std::lock_guard<std::mutex> lock(m_pendingProgressMutex);
+    if (buffer != nullptr && size > 0)
+      m_pendingProgress.assign(buffer, buffer + size);
+    else
+      m_pendingProgress.clear();
+    m_hasPendingProgress = true;
+
+    kodi::Log(ADDON_LOG_DEBUG, "CCheevos: game not identified yet, holding %zu bytes of progress",
+              size);
+
+    return true;
+  }
+
+  // A null buffer is passed through rather than refused. rcheevos treats it as
+  // "no progress to restore" and resets the runtime, which is what a savestate
+  // carrying none needs: emulator memory has jumped, so every delta, prior
+  // value and hit count the runtime holds describes a moment that no longer
+  // follows from it.
+  if (buffer == nullptr || size == 0)
+  {
+    kodi::Log(ADDON_LOG_INFO,
+              "CCheevos: savestate carries no achievement progress, runtime reset");
+
+    return rc_client_deserialize_progress_sized(m_rcClient, nullptr, 0) == RC_OK;
+  }
+
+  return rc_client_deserialize_progress_sized(m_rcClient, buffer, size) == RC_OK;
+}
+
+// HTTP server callback — uses Kodi VFS (which wraps libcurl internally)
+void CCheevos::RcheevosServerCall(const rc_api_request_t* request,
+                                  rc_client_server_callback_t callback,
+                                  void* callback_data,
+                                  rc_client_t* client)
+{
+  const std::string url = (request->url != nullptr) ? request->url : "";
+  const std::string postData = (request->post_data != nullptr) ? request->post_data : "";
+
+  CCheevos* const cheevos = static_cast<CCheevos*>(rc_client_get_userdata(client));
+
+  std::string userAgent;
+  // rc_client requires the callback to be invoked exactly once. With no
+  // instance to track the request against, or with teardown under way, answer
+  // immediately rather than starting work that would outlive the client.
+  if (cheevos == nullptr || cheevos->m_shuttingDown)
+  {
+    rc_api_server_response_t resp{};
+    resp.http_status_code = HTTP_STATUS_NO_RESPONSE;
+    callback(&resp, callback_data);
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(cheevos->m_userAgentMutex);
+    userAgent = cheevos->m_userAgent;
+  }
+
+  auto task = std::async(std::launch::async, [url, postData, userAgent, callback, callback_data]()
+  {
+    std::string responseData;
+    unsigned int statusCode = HTTP_STATUS_NO_RESPONSE;
+
+    // Options are set through the curl API rather than the "url|opt=value"
+    // syntax, because the post body is form data full of '&' and '=' which
+    // that syntax would split into further options
+    kodi::vfs::CFile file;
+    if (file.CURLCreate(url))
+    {
+      if (!userAgent.empty())
+        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "User-Agent", userAgent);
+
+      // RetroAchievements reports failures as a JSON body with a 4xx status,
+      // and rc_client needs that body to explain the failure
+      file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "failonerror", "false");
+
+      // Kodi base64-decodes this option, so it has to be encoded here
+      if (!postData.empty())
+        file.CURLAddOption(ADDON_CURL_OPTION_PROTOCOL, "postdata", Base64Encode(postData));
+
+      if (file.CURLOpen(ADDON_READ_NO_CACHE))
       {
-        pointer = desc.descriptor.ptr;
-        address -= desc.descriptor.start;
+        char buffer[HTTP_READ_CHUNK];
+        ssize_t bytesRead;
+        while ((bytesRead = file.Read(buffer, sizeof(buffer))) > 0)
+          responseData.append(buffer, static_cast<size_t>(bytesRead));
 
-        if (desc.disconnectMask)
-          address = Reduce(address & desc.disconnectMask, desc.descriptor.disconnect);
+        statusCode = ParseHttpStatus(
+            file.GetPropertyValue(ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL, ""));
 
-        if (address >= desc.descriptor.len)
-          address -= HighestBit(address);
-
-        address += desc.descriptor.offset;
-
-        break;
+        file.Close();
       }
     }
-  }
 
-  if (!pointer)
-    return NULL;
+    if (statusCode == HTTP_STATUS_NO_RESPONSE)
+      kodi::Log(ADDON_LOG_ERROR, "CCheevos: request failed: %s", url.c_str());
 
-  return (const uint8_t*)pointer + address;
-}
+    rc_api_server_response_t resp{};
+    resp.body = responseData.c_str();
+    resp.body_length = responseData.size();
+    resp.http_status_code = static_cast<int>(statusCode);
 
-size_t CCheevos::HighestBit(size_t n)
-{
-  n |= n >> 1;
-  n |= n >> 2;
-  n |= n >> 4;
-  n |= n >> 8;
-  n |= n >> 16;
+    callback(&resp, callback_data);
+  });
 
-  return n ^ (n >> 1);
-}
-
-size_t CCheevos::Reduce(size_t addr, size_t mask)
-{
-  while (mask)
+  // Tracked rather than detached: rc_client owns callback_data, so a request
+  // outliving rc_client_destroy() would invoke the callback against freed
+  // memory. Deinitialize() waits for everything held here first.
   {
-    size_t tmp = (mask - 1) & ~mask;
-    addr = (addr & tmp) | ((addr >> 1) & ~tmp);
-    mask = (mask & (mask - 1)) >> 1;
+    std::lock_guard<std::mutex> lock(cheevos->m_serverCallsMutex);
+
+    std::erase_if(cheevos->m_serverCalls, [](const std::future<void>& call)
+                  { return call.wait_for(std::chrono::seconds(0)) == std::future_status::ready; });
+
+    cheevos->m_serverCalls.emplace_back(std::move(task));
+  }
+}
+// Memory read callback
+uint32_t CCheevos::RcheevosReadMemory(uint32_t address, uint8_t* buffer,
+                                       uint32_t num_bytes, rc_client_t* client)
+{
+  CCheevos* const cheevos = static_cast<CCheevos*>(rc_client_get_userdata(client));
+  if (cheevos == nullptr)
+    return 0;
+
+  // rc_client validates every achievement's addresses as soon as the session
+  // starts, which is before the game-load callback runs. If the mapping isn't
+  // ready by then every achievement is disabled as out of range, so it is
+  // built here on first use rather than after the game has loaded.
+  if (!cheevos->m_memoryInitialized)
+  {
+    const rc_client_game_t* gameInfo = rc_client_get_game_info(client);
+    if (gameInfo == nullptr)
+      return 0;
+
+    std::lock_guard<std::mutex> lock(cheevos->m_memoryMutex);
+    if (!cheevos->m_memoryInitialized)
+    {
+      // rcheevos matches the regions a console is expected to have against the
+      // core's memory map. Without one it can only see what the core exposes as
+      // RETRO_MEMORY_SYSTEM_RAM, which is a single flat block: enough for a
+      // console whose memory is one region, and nothing at all for one that is
+      // split. The Saturn wants fourteen regions and matched none of them, so
+      // every achievement it had was reported unsupported.
+      const CMemoryMap& memoryMap = CLibretroEnvironment::Get().GetMemoryMap();
+
+      std::vector<retro_memory_descriptor> descriptors;
+      descriptors.reserve(memoryMap.Size());
+      for (size_t i = 0; i < memoryMap.Size(); ++i)
+        descriptors.emplace_back(memoryMap[static_cast<int>(i)].descriptor);
+
+      retro_memory_map retroMemoryMap{};
+      retroMemoryMap.descriptors = descriptors.data();
+      retroMemoryMap.num_descriptors = static_cast<unsigned int>(descriptors.size());
+
+      // A core that publishes no map is no worse off than before, and still
+      // gets whatever it exposes as system RAM
+      s_memoryInfoInstance = cheevos;
+      rc_libretro_memory_init(&cheevos->m_memoryRegions,
+                              descriptors.empty() ? nullptr : &retroMemoryMap,
+                              RcheevosGetCoreMemoryInfo, gameInfo->console_id);
+      s_memoryInfoInstance = nullptr;
+      cheevos->m_memoryInitialized = true;
+
+      kodi::Log(ADDON_LOG_INFO,
+                "CCheevos: memory mapped for console %u from %zu descriptors, total_size=%u",
+                gameInfo->console_id, descriptors.size(),
+                cheevos->m_memoryRegions.total_size);
+    }
   }
 
-  return addr;
+  return rc_libretro_memory_read(&cheevos->m_memoryRegions, address, buffer, num_bytes);
+}
+
+void CCheevos::RcheevosGetCoreMemoryInfo(unsigned int id,
+                                          rc_libretro_core_memory_info_t* info)
+{
+  if (s_memoryInfoInstance == nullptr || !s_memoryInfoInstance->m_memoryCallback || info == nullptr)
+    return;
+
+  uint8_t* data = nullptr;
+  size_t size = 0;
+  s_memoryInfoInstance->m_memoryCallback(id, data, size);
+  info->data = data;
+  info->size = size;
+}
+
+// Event handler
+void CCheevos::RcheevosEventHandler(const rc_client_event_t* event, rc_client_t* client)
+{
+  CCheevos* const cheevos = static_cast<CCheevos*>(rc_client_get_userdata(client));
+  if (cheevos == nullptr || cheevos->m_gameInstance == nullptr)
+    return;
+
+  switch (event->type)
+  {
+    case RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED:
+    {
+      const rc_client_achievement_t* ach = event->achievement;
+      if (ach != nullptr)
+      {
+        game_rc_achievement_triggered data{};
+        data.id = ach->id;
+        data.title = ach->title;
+        data.description = ach->description;
+        data.badge_url = ach->badge_url;
+        data.points = ach->points;
+        data.hardcore = (rc_client_get_hardcore_enabled(client) != 0);
+
+        kodi::Log(ADDON_LOG_INFO, "CCheevos: achievement triggered id=%u '%s'",
+                  ach->id, ach->title != nullptr ? ach->title : "");
+
+        cheevos->m_gameInstance->RCOnAchievementTriggered(data);
+      }
+      break;
+    }
+    case RC_CLIENT_EVENT_GAME_COMPLETED:
+    {
+      const rc_client_game_t* gi = rc_client_get_game_info(client);
+      const char* title = (gi != nullptr && gi->title != nullptr) ? gi->title : "";
+      cheevos->m_gameInstance->RCOnGameCompleted(
+          title, rc_client_get_hardcore_enabled(client) != 0);
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
+    {
+      // rc_client reports one achievement at a time, but the frontend shows a
+      // snapshot of every measured achievement, so publish the whole set
+      cheevos->PublishAchievementProgress();
+      break;
+    }
+    case RC_CLIENT_EVENT_SERVER_ERROR:
+    {
+      const rc_client_server_error_t* err = event->server_error;
+      const char* message = (err != nullptr && err->error_message != nullptr) ? err->error_message
+                                                                             : "Unknown error";
+      const char* api = (err != nullptr && err->api != nullptr) ? err->api : "";
+
+      kodi::Log(ADDON_LOG_WARNING, "CCheevos: server error from RetroAchievements: %s", message);
+      cheevos->m_gameInstance->RCOnServerError(message, api);
+      break;
+    }
+    case RC_CLIENT_EVENT_DISCONNECTED:
+    {
+      kodi::Log(ADDON_LOG_WARNING, "CCheevos: disconnected from RetroAchievements");
+      cheevos->m_gameInstance->RCOnConnectionChanged(false);
+      break;
+    }
+    case RC_CLIENT_EVENT_RECONNECTED:
+    {
+      kodi::Log(ADDON_LOG_INFO, "CCheevos: reconnected to RetroAchievements");
+      cheevos->m_gameInstance->RCOnConnectionChanged(true);
+      break;
+    }
+    default:
+      kodi::Log(ADDON_LOG_DEBUG, "CCheevos: unhandled event %d", event->type);
+      break;
+  }
+}
+
+// Login callback
+void CCheevos::RcheevosLoginCallback(int result, const char* errorMessage,
+                                      rc_client_t* client, void* userdata)
+{
+  CCheevos* cheevos = static_cast<CCheevos*>(userdata);
+  if (cheevos == nullptr || cheevos->m_gameInstance == nullptr)
+    return;
+
+  if (result != RC_OK)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "CCheevos: login failed: %s",
+              errorMessage != nullptr ? errorMessage : "unknown error");
+
+    // Let the next credentials try again. This guard exists to stop a second
+    // login racing one already in flight, not to make failure permanent --
+    // left set, a corrected username or token could not start a login until
+    // the game was unloaded.
+    cheevos->m_loginStarted = false;
+
+    game_rc_login_result data{};
+    data.success = false;
+    data.error_message = errorMessage;
+
+    // Kodi drops the stored token when the account is rejected, so say which
+    // this was. A server that could not be reached is a reason to try again
+    // later, not to sign the player out and lose what we would retry with.
+    data.credentials_rejected = (result == RC_INVALID_CREDENTIALS ||
+                                 result == RC_EXPIRED_TOKEN || result == RC_ACCESS_DENIED);
+
+    cheevos->m_gameInstance->RCOnLoginResult(data);
+    return;
+  }
+
+  const rc_client_user_t* user = rc_client_get_user_info(client);
+  if (user != nullptr)
+  {
+    {
+      std::lock_guard<std::mutex> lock(cheevos->m_credentialsMutex);
+      cheevos->m_loginToken = (user->token != nullptr) ? user->token : "";
+      cheevos->m_userName = (user->username != nullptr) ? user->username : cheevos->m_userName;
+    }
+
+    game_rc_login_result data{};
+    data.success = true;
+    data.username = user->username;
+    data.display_name = user->display_name;
+    data.icon_url = user->avatar_url;
+    data.points = user->score;
+    cheevos->m_gameInstance->RCOnLoginResult(data);
+
+    kodi::Log(ADDON_LOG_INFO, "CCheevos: logged in as '%s' (%u points)",
+              user->username != nullptr ? user->username : "", user->score);
+  }
+
+  // Now identify and load the game
+  if (!cheevos->m_gamePath.empty())
+  {
+    kodi::Log(ADDON_LOG_INFO, "CCheevos: identifying game: %s", cheevos->m_gamePath.c_str());
+
+    // rc_hash_generate_from_file() rejects RC_CONSOLE_UNKNOWN: its console
+    // switch has no case for it and the default arm returns an error, so it
+    // cannot identify a game whose console isn't known up front. Let rc_client
+    // do the identification instead, which tries every hashing method that
+    // suits the file rather than requiring the console to be named.
+    rc_client_begin_identify_and_load_game(client, RC_CONSOLE_UNKNOWN,
+                                           cheevos->m_gamePath.c_str(), nullptr, 0,
+                                           RcheevosGameLoadCallback, cheevos);
+  }
+}
+
+// Game load callback
+void CCheevos::RcheevosGameLoadCallback(int result, const char* errorMessage,
+                                         rc_client_t* client, void* userdata)
+{
+  CCheevos* cheevos = static_cast<CCheevos*>(userdata);
+  if (cheevos == nullptr || cheevos->m_gameInstance == nullptr)
+    return;
+
+  if (result != RC_OK)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "CCheevos: game load failed: %s",
+              errorMessage != nullptr ? errorMessage : "unknown error");
+    return;
+  }
+
+  const rc_client_game_t* gameInfo = rc_client_get_game_info(client);
+
+  // When RetroAchievements doesn't recognise a ROM's hash it still resolves it,
+  // to a placeholder game titled "Unsupported Game Version (<real game>)" that
+  // holds a single always-true achievement. Left alone that achievement fires
+  // immediately, which reads as an unlock and then as having mastered a
+  // one-achievement game. Treat the placeholder as an unsupported game instead.
+  //
+  // Keyed on the title because that is what the server sends; there is no flag
+  // for it in the response.
+  if (gameInfo != nullptr && gameInfo->title != nullptr &&
+      std::strncmp(gameInfo->title, "Unsupported Game Version", 24) == 0)
+  {
+    kodi::Log(ADDON_LOG_INFO, "CCheevos: '%s' - this ROM version has no achievements",
+              gameInfo->title);
+
+    game_rc_game_loaded empty{};
+    cheevos->m_gameInstance->RCOnGameLoaded(empty);
+    return;
+  }
+
+  // Build achievement list
+  // Note: string pointers in these structs reference rc_client-owned memory,
+  // which remains valid until rc_client_destroy_achievement_list() is called below.
+  std::vector<game_rc_achievement> achievements;
+  rc_client_achievement_list_t* achList = rc_client_create_achievement_list(
+      client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+      RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+  if (achList != nullptr)
+  {
+    for (uint32_t b = 0; b < achList->num_buckets; ++b)
+    {
+      const auto& bucket = achList->buckets[b];
+      for (uint32_t a = 0; a < bucket.num_achievements; ++a)
+      {
+        const rc_client_achievement_t* ach = bucket.achievements[a];
+
+        // Skip system notices such as "Warning: Unknown Emulator". They are
+        // published as zero-point achievements marked unlocked, which would
+        // otherwise be listed and counted as if the player had earned them.
+        if (ach->title != nullptr && std::strncmp(ach->title, "Warning:", 8) == 0)
+        {
+          kodi::Log(ADDON_LOG_INFO, "CCheevos: skipping system notice '%s'", ach->title);
+          continue;
+        }
+
+        game_rc_achievement gach{};
+        gach.id = ach->id;
+        gach.title = ach->title;
+        gach.description = ach->description;
+        gach.badge_url = ach->badge_url;
+        gach.badge_locked_url = ach->badge_locked_url;
+        gach.points = ach->points;
+        gach.unlock_state = TranslateUnlockState(ach->unlocked);
+        gach.unlock_time = static_cast<int64_t>(ach->unlock_time);
+        gach.rarity = ach->rarity;
+        gach.rarity_hardcore = ach->rarity_hardcore;
+        achievements.push_back(gach);
+      }
+    }
+    rc_client_destroy_achievement_list(achList);
+  }
+
+  // Build and fire the game-loaded event. Kodi counts the achievements and
+  // how many are earned from the list itself, so no separate totals are sent.
+  game_rc_game_loaded data{};
+  data.game_id = (gameInfo != nullptr) ? gameInfo->id : 0;
+  data.title = (gameInfo != nullptr) ? gameInfo->title : "";
+  data.icon_url = (gameInfo != nullptr) ? gameInfo->badge_url : nullptr;
+  data.achievements = achievements.data();
+  data.achievement_count = static_cast<unsigned int>(achievements.size());
+
+  kodi::Log(ADDON_LOG_INFO, "CCheevos: loaded '%s' (%u achievements)",
+            data.title != nullptr ? data.title : "", data.achievement_count);
+
+  cheevos->m_gameInstance->RCOnGameLoaded(data);
+
+  cheevos->ApplyPendingProgress();
+
+  // Start rich presence ping thread
+  cheevos->m_richPresenceRunning = true;
+  cheevos->m_richPresenceThread = std::thread(&CCheevos::RichPresencePingThread, cheevos);
+}
+
+// Rich presence ping thread
+void CCheevos::RichPresencePingThread()
+{
+  while (m_richPresenceRunning)
+  {
+    if (m_rcClient != nullptr && m_gameInstance != nullptr)
+    {
+      char buffer[RP_BUFFER_SIZE]{};
+      rc_client_get_rich_presence_message(m_rcClient, buffer, sizeof(buffer));
+      const std::string rpMessage(buffer);
+
+      if (!rpMessage.empty())
+        m_gameInstance->RCOnRichPresenceUpdated(rpMessage.c_str());
+    }
+
+    for (int i = 0; i < (RP_PING_INTERVAL_MS / RP_SLEEP_INTERVAL_MS) && m_richPresenceRunning; ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(RP_SLEEP_INTERVAL_MS));
+  }
 }

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -1,80 +1,191 @@
 /*
- *  Copyright (C) 2014-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.
  */
-
 #pragma once
 
-#include "rcheevos/rcheevos.h"
-
+#include <atomic>
 #include <functional>
-#include <memory>
-#include <stdint.h>
+#include <future>
+#include <mutex>
 #include <string>
-#include <unordered_map>
+#include <thread>
 #include <vector>
+
+#define RC_CLIENT_SUPPORTS_HASH
+#include <rcheevos/rc_client.h>
+#include <rcheevos/rc_libretro.h>
+
+namespace kodi
+{
+namespace addon
+{
+class CInstanceGame;
+}
+} // namespace kodi
 
 namespace LIBRETRO
 {
-class CMemoryMap;
+
+/// @brief Callback to read core memory: (type) -> (data_ptr, size)
+using MemoryAccessCallback = std::function<bool(unsigned int type, uint8_t*& data, size_t& size)>;
 
 class CCheevos
 {
 public:
   CCheevos();
   static CCheevos& Get();
-  void Initialize();
+
+  /// @brief Initialize rc_client and begin login + game identification
+  void Initialize(kodi::addon::CInstanceGame* gameInstance,
+                  const std::string& gamePath,
+                  MemoryAccessCallback memoryCallback);
   void Deinitialize();
-  // When the game is reset, the runtime should also be reset
-  void ResetRuntime();
-  bool GenerateHashFromFile(std::string& hash, unsigned int consoleID, const std::string& filePath);
-  bool GetGameIDUrl(std::string& url, const std::string& hash);
-  void SetRetroAchievementsCredentials(const std::string& username, const std::string& token);
-  bool GetPatchFileUrl(std::string& url,
-                       const std::string& username,
-                       const std::string& token,
-                       unsigned int gameID);
-  bool PostRichPresenceUrl(std::string& url,
-                           std::string& postData,
-                           const std::string& username,
-                           const std::string& token,
-                           unsigned int gameID,
-                           const std::string& richPresence);
-  void EnableRichPresence(const std::string& script);
-  void EvaluateRichPresence(std::string& evaluation, unsigned int consoleID);
-  bool ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression);
-  bool AwardAchievement(
-      char* url, size_t size, unsigned cheevo_id, int hardcore, const std::string& game_hash);
-  void DeactivateTriggeredAchievement(unsigned cheevo_id);
-  void TestCheevoStatusPerFrame();
-  unsigned int Peek(unsigned int address, unsigned int numBytes);
-  void GetCheevoUrlId(const std::function<void(const std::string& achievementUrl, unsigned int cheevoId)>& callback);
+
+  /// @brief Store credentials from Kodi (called before LoadGame)
+  void SetCredentials(const std::string& username, const std::string& token);
+
+  /// @brief Called every emulated frame from RunFrame()
+  void DoFrame();
+
+  /*!
+   * @brief Send progress for every measured achievement to the frontend
+   *
+   * rc_client's progress-indicator events name a single achievement, but the
+   * frontend renders a snapshot of the whole list, so the full set is
+   * published whenever any of it changes.
+   */
+  void PublishAchievementProgress();
+
+  /*!
+   * @brief Size of the achievement progress blob, or 0 if there is nothing to save
+   *
+   * Returns 0 when no game is loaded in rc_client, so that savestates taken
+   * with achievements inactive keep their original layout.
+   */
+  size_t ProgressSize();
+
+  /*!
+   * @brief Whether the achievement runtime exists at all
+   *
+   * True once rc_client has been created, which happens before it has
+   * finished identifying the game. Distinguishes "achievements are in use but
+   * not ready yet" from "achievements are switched off", so that savestates
+   * only carry the cost of reserved progress space when it can be needed.
+   */
+  bool IsActive() const { return m_rcClient != nullptr; }
+
+  /*!
+   * @brief Serialize achievement progress into a bounded buffer
+   *
+   * \param buffer Destination
+   * \param size Bytes available in \p buffer
+   * \return Bytes written, or 0 if progress could not be saved
+   */
+  size_t SerializeProgress(uint8_t* buffer, size_t size);
+
+  /*!
+   * @brief Restore achievement progress previously written by SerializeProgress()
+   *
+   * \return True on success. A failure is not fatal: the emulator state is
+   *         still restored, the achievement runtime just keeps its current
+   *         state.
+   */
+  bool DeserializeProgress(const uint8_t* buffer, size_t size);
 
 private:
-  const uint8_t* FixupFind(unsigned address, CMemoryMap& mmap, unsigned int consoleID);
-  const uint8_t* PatchAddress(size_t address, CMemoryMap& mmap, unsigned int consoleID);
-  size_t HighestBit(size_t n);
-  size_t Reduce(size_t addr, size_t mask);
+  /*!
+   * @brief Apply progress that arrived before the game had been identified
+   *
+   * Called once the game load completes. See DeserializeProgress().
+   */
+  void ApplyPendingProgress();
 
-  static unsigned int PeekInternal(unsigned address, unsigned num_bytes, void* ud);
-  static void RuntimeEventHandler(const rc_runtime_event_t* runtime_event);
+  /*!
+   * @brief Start the login if the client is up and credentials are known
+   *
+   * Called from both Initialize() and SetCredentials(), because the frontend
+   * may supply credentials either before or after the game is loaded. Does
+   * nothing on the second call.
+   */
+  void BeginLogin();
 
-  std::function<void(const std::string& achievementUrl, unsigned int cheevoId)> m_callback;
+  // rc_client C callbacks (static — use s_instance to get back to instance)
+  static void RcheevosEventHandler(const rc_client_event_t* event, rc_client_t* client);
+  static void RcheevosServerCall(const rc_api_request_t* request,
+                                 rc_client_server_callback_t callback,
+                                 void* callback_data,
+                                 rc_client_t* client);
+  static uint32_t RcheevosReadMemory(uint32_t address, uint8_t* buffer,
+                                     uint32_t num_bytes, rc_client_t* client);
+  static void RcheevosGetCoreMemoryInfo(unsigned int id,
+                                         rc_libretro_core_memory_info_t* info);
+  static void RcheevosLoginCallback(int result, const char* errorMessage, rc_client_t* client,
+                                    void* userdata);
+  static void RcheevosGameLoadCallback(int result, const char* errorMessage, rc_client_t* client,
+                                       void* userdata);
 
-  unsigned int m_consoleID{0};
+  // Rich presence ping thread
+  void RichPresencePingThread();
 
-  rc_runtime_t m_runtime;
-  std::unordered_map<unsigned, const uint8_t*> m_addressFixups;
+  // rc_client state
+  rc_client_t* m_rcClient{nullptr};
+  kodi::addon::CInstanceGame* m_gameInstance{nullptr};
+  std::string m_gamePath;
 
-  // Rich Presence
-  rc_richpresence_t* m_richPresence = nullptr;
-  std::string m_richPresenceScript;
-  std::vector<char> m_richPresenceBuffer;
+  // Credentials (guarded by m_credentialsMutex)
+  std::string m_userName;
+  std::string m_loginToken;
+  mutable std::mutex m_credentialsMutex;
 
-  std::string m_hash;
-  std::string m_username;
-  std::string m_token;
+  // Identifies this add-on to RetroAchievements, built once in Initialize()
+  std::string m_userAgent;
+  mutable std::mutex m_userAgentMutex;
+  std::atomic<bool> m_loginStarted{false};
+
+  // Memory access
+  MemoryAccessCallback m_memoryCallback;
+  rc_libretro_memory_regions_t m_memoryRegions{};
+  /*!
+   * @brief Rebuild the achievement list for progress roughly once a second
+   *
+   * Cores run at 50-60Hz, so this is close enough to a second on any of them
+   * without needing a clock.
+   */
+  static constexpr unsigned int PROGRESS_PUBLISH_INTERVAL_FRAMES = 60;
+  unsigned int m_framesSincePublish{0};
+
+  /// @brief Last published progress, used to suppress unchanged updates
+  std::string m_lastProgressSignature;
+
+  /// @brief Whether the "progress doesn't fit" warning has been issued
+  bool m_progressTooLargeWarned{false};
+
+  std::atomic<bool> m_memoryInitialized{false};
+  std::mutex m_memoryMutex;
+
+  // Progress handed over before the game was identified, applied once it is.
+  // Empty with the flag set means a reset was asked for.
+  std::mutex m_pendingProgressMutex;
+  std::vector<uint8_t> m_pendingProgress;
+  bool m_hasPendingProgress{false};
+
+  // Background threads
+  std::atomic<bool> m_richPresenceRunning{false};
+  std::thread m_richPresenceThread;
+  /*!
+   * @brief In-flight HTTP requests to RetroAchievements
+   *
+   * Each holds a callback_data pointer owned by rc_client, so these are waited
+   * on in Deinitialize() before the client is destroyed rather than detached.
+   */
+  std::vector<std::future<void>> m_serverCalls;
+  std::mutex m_serverCallsMutex;
+
+  /// @brief Set during teardown so no further requests reach the network
+  std::atomic<bool> m_shuttingDown{false};
 };
+
 } // namespace LIBRETRO

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <future>
 #include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #define RC_CLIENT_SUPPORTS_HASH
@@ -49,6 +49,9 @@ public:
 
   /// @brief Called every emulated frame from RunFrame()
   void DoFrame();
+
+  /// @brief Reset the loaded achievement runtime after the core resets
+  void ResetRuntime();
 
   /*!
    * @brief Send progress for every measured achievement to the frontend
@@ -96,6 +99,14 @@ public:
   bool DeserializeProgress(const uint8_t* buffer, size_t size);
 
 private:
+  struct ServerResponse
+  {
+    rc_client_server_callback_t callback{nullptr};
+    void* callbackData{nullptr};
+    std::string body;
+    int statusCode{0};
+  };
+
   /*!
    * @brief Apply progress that arrived before the game had been identified
    *
@@ -111,6 +122,14 @@ private:
    * nothing on the second call.
    */
   void BeginLogin();
+  void BeginGameLoad();
+
+  void QueueServerResponse(rc_client_server_callback_t callback,
+                           void* callbackData,
+                           std::string body,
+                           int statusCode);
+  void DispatchServerResponses();
+  void UpdateRichPresence();
 
   // rc_client C callbacks (static — use s_instance to get back to instance)
   static void RcheevosEventHandler(const rc_client_event_t* event, rc_client_t* client);
@@ -127,9 +146,6 @@ private:
   static void RcheevosGameLoadCallback(int result, const char* errorMessage, rc_client_t* client,
                                        void* userdata);
 
-  // Rich presence ping thread
-  void RichPresencePingThread();
-
   // rc_client state
   rc_client_t* m_rcClient{nullptr};
   kodi::addon::CInstanceGame* m_gameInstance{nullptr};
@@ -144,6 +160,12 @@ private:
   std::string m_userAgent;
   mutable std::mutex m_userAgentMutex;
   std::atomic<bool> m_loginStarted{false};
+  bool m_loginRetryScheduled{false};
+  unsigned int m_loginRetryDelaySeconds{0};
+  std::chrono::steady_clock::time_point m_nextLoginAttempt;
+  bool m_gameLoadRetryScheduled{false};
+  unsigned int m_gameLoadRetryDelaySeconds{0};
+  std::chrono::steady_clock::time_point m_nextGameLoadAttempt;
 
   // Memory access
   MemoryAccessCallback m_memoryCallback;
@@ -172,16 +194,17 @@ private:
   std::vector<uint8_t> m_pendingProgress;
   bool m_hasPendingProgress{false};
 
-  // Background threads
-  std::atomic<bool> m_richPresenceRunning{false};
-  std::thread m_richPresenceThread;
+  bool m_richPresenceActive{false};
+  std::chrono::steady_clock::time_point m_nextRichPresencePing;
+
   /*!
    * @brief In-flight HTTP requests to RetroAchievements
    *
-   * Each holds a callback_data pointer owned by rc_client, so these are waited
-   * on in Deinitialize() before the client is destroyed rather than detached.
+   * The workers only perform network I/O. Their responses are dispatched on
+   * the game thread while callback_data is still owned by rc_client.
    */
   std::vector<std::future<void>> m_serverCalls;
+  std::vector<ServerResponse> m_serverResponses;
   std::mutex m_serverCallsMutex;
 
   /// @brief Set during teardown so no further requests reach the network

--- a/src/cheevos/CheevosFrontendBridge.cpp
+++ b/src/cheevos/CheevosFrontendBridge.cpp
@@ -47,13 +47,9 @@ int64_t CCheevosFrontendBridge::GetPosition(void* file_handle)
 
   FileHandle *fileHandle = static_cast<FileHandle*>(file_handle);
 
-  const int64_t currentPosition = fileHandle->file->GetPosition();
-
-  if (currentPosition < 0)
-    return -1;
-
-  // Return the current read / write position for the file
-  return currentPosition;
+  // Report the position we have tracked rather than asking the VFS, which
+  // cannot always answer. See Seek() for why that distinction matters.
+  return fileHandle->position;
 }
 
 void CCheevosFrontendBridge::Seek(void* file_handle, int64_t offset, int origin)
@@ -63,27 +59,49 @@ void CCheevosFrontendBridge::Seek(void* file_handle, int64_t offset, int origin)
 
   FileHandle *fileHandle = static_cast<FileHandle*>(file_handle);
 
-  int whence = -1;
+  // Resolve the destination to an absolute offset here rather than handing the
+  // origin to the VFS.
+  //
+  // rcheevos has no call for a file's size: it seeks to the end and asks where
+  // it landed. Not every VFS backend can seek, though. vfs.libarchive fails
+  // inside a compressed entry and, worse, stores the failure as its position,
+  // so the answer that comes back is negative. rc_hash_whole_file() takes that
+  // as the size, and `remaining = (size_t)-1` has it hash sixteen exabytes of
+  // stale buffer -- an unbreakable loop that hangs the add-on for good, since
+  // the read return value it would need to notice is discarded.
+  //
+  // GetLength() those backends do answer, so ask that for SEEK_END, and track
+  // the position ourselves so nothing negative can reach rcheevos.
+  int64_t position = offset;
 
   switch (origin)
   {
-  case 0:
-    whence = SEEK_SET;
+  case 0: // SEEK_SET
     break;
-  case 1:
-    whence = SEEK_CUR;
+  case 1: // SEEK_CUR
+    position += fileHandle->position;
     break;
-  case 2:
-    whence = SEEK_END;
-    break;
-  default:
+  case 2: // SEEK_END
+  {
+    const int64_t length = fileHandle->file->GetLength();
+    if (length < 0)
+      return;
+    position += length;
     break;
   }
+  default:
+    return;
+  }
 
-  if (whence == -1)
+  if (position < 0)
     return;
 
-  fileHandle->file->Seek(offset, whence);
+  // Keep the requested position when the backend can't seek. rcheevos measures
+  // the file this way and then reads it from the start, which a stream sitting
+  // at its start still serves correctly.
+  const int64_t reached = fileHandle->file->Seek(position, SEEK_SET);
+
+  fileHandle->position = (reached < 0) ? position : reached;
 }
 
 size_t CCheevosFrontendBridge::ReadFile(void* file_handle, void* buffer, size_t requested_bytes)
@@ -103,6 +121,8 @@ size_t CCheevosFrontendBridge::ReadFile(void* file_handle, void* buffer, size_t 
   // undetectable error occurred
   if (bytesRead == 0)
     return 0;
+
+  fileHandle->position += bytesRead;
 
   // Return the number of bytes read
   return static_cast<size_t>(bytesRead);

--- a/src/cheevos/CheevosFrontendBridge.cpp
+++ b/src/cheevos/CheevosFrontendBridge.cpp
@@ -96,12 +96,41 @@ void CCheevosFrontendBridge::Seek(void* file_handle, int64_t offset, int origin)
   if (position < 0)
     return;
 
-  // Keep the requested position when the backend can't seek. rcheevos measures
-  // the file this way and then reads it from the start, which a stream sitting
-  // at its start still serves correctly.
   const int64_t reached = fileHandle->file->Seek(position, SEEK_SET);
+  if (reached >= 0)
+  {
+    fileHandle->position = reached;
+    return;
+  }
 
-  fileHandle->position = (reached < 0) ? position : reached;
+  // rcheevos uses SEEK_END only to measure the file before seeking elsewhere.
+  if (origin == SEEK_END && offset == 0)
+  {
+    fileHandle->position = position;
+    return;
+  }
+
+  std::unique_ptr<kodi::vfs::CFile> reopened(new kodi::vfs::CFile);
+  if (!reopened->OpenFile(fileHandle->path, 0))
+    return;
+
+  char buffer[64 * 1024];
+  int64_t remaining = position;
+  while (remaining > 0)
+  {
+    const size_t chunkSize = remaining < static_cast<int64_t>(sizeof(buffer))
+                                 ? static_cast<size_t>(remaining)
+                                 : sizeof(buffer);
+    const ssize_t bytesRead = reopened->Read(buffer, chunkSize);
+    if (bytesRead <= 0)
+      return;
+
+    remaining -= bytesRead;
+  }
+
+  fileHandle->file->Close();
+  fileHandle->file = std::move(reopened);
+  fileHandle->position = position;
 }
 
 size_t CCheevosFrontendBridge::ReadFile(void* file_handle, void* buffer, size_t requested_bytes)

--- a/src/cheevos/CheevosFrontendBridge.h
+++ b/src/cheevos/CheevosFrontendBridge.h
@@ -42,6 +42,9 @@ namespace LIBRETRO
     {
       std::string path;
       std::unique_ptr<kodi::vfs::CFile> file;
+
+      //! \brief The read position as reported to rcheevos, which is never negative
+      int64_t position{0};
     };
   };
 } // namespace LIBRETRO

--- a/src/cheevos/CheevosUtils.cpp
+++ b/src/cheevos/CheevosUtils.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "CheevosUtils.h"
+
+#include <cstdlib>
+
+#define RC_CLIENT_SUPPORTS_HASH
+#include <rcheevos/rc_client.h>
+
+namespace LIBRETRO
+{
+GAME_RC_UNLOCK_STATE TranslateUnlockState(uint8_t unlocked)
+{
+  if ((unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE) != 0)
+    return GAME_RC_UNLOCK_STATE_HARDCORE;
+  if ((unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE) != 0)
+    return GAME_RC_UNLOCK_STATE_SOFTCORE;
+
+  return GAME_RC_UNLOCK_STATE_LOCKED;
+}
+
+unsigned int ParseHttpStatus(const std::string& responseProtocol)
+{
+  const size_t start = responseProtocol.find(' ');
+  if (start == std::string::npos)
+    return HTTP_STATUS_NO_RESPONSE;
+
+  return static_cast<unsigned int>(std::strtoul(responseProtocol.c_str() + start + 1, nullptr, 10));
+}
+} // namespace LIBRETRO

--- a/src/cheevos/CheevosUtils.h
+++ b/src/cheevos/CheevosUtils.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+#include <kodi/addon-instance/Game.h>
+
+namespace LIBRETRO
+{
+/*!
+ * \brief The status code reported when no HTTP response was received at all
+ */
+constexpr unsigned int HTTP_STATUS_NO_RESPONSE = 0;
+
+/*!
+ * \brief Translate rc_client's unlock bitmask into the Game API's enum
+ *
+ * rc_client reports softcore and hardcore as independent bits. Kodi only needs
+ * to know the strongest state the achievement has been earned in.
+ */
+GAME_RC_UNLOCK_STATE TranslateUnlockState(uint8_t unlocked);
+
+/*!
+ * \brief Extract the status code from an HTTP response line
+ *
+ * \param responseProtocol A line such as "HTTP/1.1 404 Not Found"
+ *
+ * \return The status code, or HTTP_STATUS_NO_RESPONSE if it can't be read
+ */
+unsigned int ParseHttpStatus(const std::string& responseProtocol);
+} // namespace LIBRETRO

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -305,6 +305,7 @@ GAME_ERROR CGameLibRetro::RunFrame()
 GAME_ERROR CGameLibRetro::Reset()
 {
   m_client.retro_reset();
+  CCheevos::Get().ResetRuntime();
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -91,7 +91,6 @@ ADDON_STATUS CGameLibRetro::Create()
     CButtonMapper::Get().LoadButtonMap();
     CControllerTopology::GetInstance().LoadTopology();
 
-    CCheevos::Get().Initialize();
 
     m_client.retro_init();
 
@@ -184,7 +183,20 @@ GAME_ERROR CGameLibRetro::LoadGame(const std::string& url)
     bResult = m_client.retro_load_game(&gameInfo);
   }
 
-  return bResult ? GAME_ERROR_NO_ERROR : GAME_ERROR_FAILED;
+  if (bResult)
+  {
+    CCheevos::Get().Initialize(this, url,
+                               [this](unsigned int type, uint8_t*& data, size_t& size) -> bool
+                               {
+                                 data = static_cast<uint8_t*>(
+                                     m_client.retro_get_memory_data(type));
+                                 size = m_client.retro_get_memory_size(type);
+                                 return data != nullptr && size > 0;
+                               });
+    return GAME_ERROR_NO_ERROR;
+  }
+
+  return GAME_ERROR_FAILED;
 }
 
 GAME_ERROR CGameLibRetro::LoadGameSpecial(SPECIAL_GAME_TYPE type, const std::vector<std::string>& urls)
@@ -234,6 +246,7 @@ GAME_ERROR CGameLibRetro::UnloadGame()
 {
   GAME_ERROR error = GAME_ERROR_FAILED;
 
+  CCheevos::Get().Deinitialize();
   m_client.retro_unload_game();
 
   CLibretroEnvironment::Get().CloseStreams();
@@ -282,7 +295,7 @@ GAME_ERROR CGameLibRetro::RunFrame()
 
   m_client.retro_run();
 
-  CCheevos::Get().TestCheevoStatusPerFrame();
+  CCheevos::Get().DoFrame();
 
   CLibretroEnvironment::Get().OnFrameEnd();
 
@@ -462,6 +475,39 @@ GAME_ERROR CGameLibRetro::Deserialize(const uint8_t* data, size_t size)
   return result ? GAME_ERROR_NO_ERROR : GAME_ERROR_FAILED;
 }
 
+size_t CGameLibRetro::AchievementStateSize()
+{
+  return CCheevos::Get().ProgressSize();
+}
+
+GAME_ERROR CGameLibRetro::SerializeAchievements(uint8_t* data, size_t size)
+{
+  if (data == nullptr || size == 0)
+    return GAME_ERROR_INVALID_PARAMETERS;
+
+  // The frontend asked how much was needed and sized the buffer from the
+  // answer, so a short write here means the runtime grew in between rather
+  // than anything being wrong
+  if (CCheevos::Get().SerializeProgress(data, size) == 0)
+    return GAME_ERROR_FAILED;
+
+  return GAME_ERROR_NO_ERROR;
+}
+
+GAME_ERROR CGameLibRetro::DeserializeAchievements(const uint8_t* data, size_t size)
+{
+  // An empty payload is passed on rather than refused. A savestate written
+  // before this existed, or while signed out, carries no progress -- but the
+  // runtime still has to be told the machine state jumped, or the hit counts
+  // it holds for the abandoned timeline would survive the restore and could
+  // fire a trigger the player never earned. DeserializeProgress() resets on
+  // an empty buffer for exactly that reason.
+  if (!CCheevos::Get().DeserializeProgress(data, size))
+    return GAME_ERROR_FAILED;
+
+  return GAME_ERROR_NO_ERROR;
+}
+
 GAME_ERROR CGameLibRetro::CheatReset()
 {
   m_client.retro_cheat_reset();
@@ -484,89 +530,20 @@ GAME_ERROR CGameLibRetro::SetCheat(unsigned int index, bool enabled, const std::
   return GAME_ERROR_NO_ERROR;
 }
 
-GAME_ERROR CGameLibRetro::RCGenerateHashFromFile(std::string& hash,
-                                                 unsigned int consoleID,
-                                                 const std::string& filePath)
-{
-  if (!CCheevos::Get().GenerateHashFromFile(hash, consoleID, filePath))
-    return GAME_ERROR_FAILED;
-
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCGetGameIDUrl(std::string& url, const std::string& hash)
-{
-  if (!CCheevos::Get().GetGameIDUrl(url, hash))
-    return GAME_ERROR_FAILED;
-
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCGetPatchFileUrl(std::string& url,
-                                            const std::string& username,
-                                            const std::string& token,
-                                            unsigned int gameID)
-{
-  if (!CCheevos::Get().GetPatchFileUrl(url, username, token, gameID))
-    return GAME_ERROR_FAILED;
-
-  return GAME_ERROR_NO_ERROR;
-}
-
 GAME_ERROR CGameLibRetro::SetRetroAchievementsCredentials(const std::string& username, const std::string& token)
 {
-  CCheevos::Get().SetRetroAchievementsCredentials(username, token);
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCPostRichPresenceUrl(std::string& url,
-                                                std::string& postData,
-                                                const std::string& username,
-                                                const std::string& token,
-                                                unsigned int gameID,
-                                                const std::string& richPresence)
-{
-  if (!CCheevos::Get().PostRichPresenceUrl(url, postData, username, token, gameID, richPresence))
-    return GAME_ERROR_FAILED;
-
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCEnableRichPresence(const std::string& script)
-{
-  CCheevos::Get().EnableRichPresence(script);
-
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCGetRichPresenceEvaluation(std::string& evaluation,
-                                                      unsigned int consoleID)
-{
-  CCheevos::Get().EvaluateRichPresence(evaluation, consoleID);
-
+  CCheevos::Get().SetCredentials(username, token);
   return GAME_ERROR_NO_ERROR;
 }
 
 GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression)
 {
-  if (!CCheevos::Get().ActivateAchievement(cheevo_id, memAddrExpression))
-    return GAME_ERROR_FAILED;
-
-  return GAME_ERROR_NO_ERROR;
+  return GAME_ERROR_NOT_IMPLEMENTED;
 }
-
 
 GAME_ERROR CGameLibRetro::GetCheevoUrlId(const std::function<void(const std::string& achievementUrl, unsigned int cheevoId)>& callback)
 {
-  CCheevos::Get().GetCheevoUrlId(callback);
-  return GAME_ERROR_NO_ERROR;
-}
-
-GAME_ERROR CGameLibRetro::RCResetRuntime()
-{
-  CCheevos::Get().ResetRuntime();
-
-  return GAME_ERROR_NO_ERROR;
+  return GAME_ERROR_NOT_IMPLEMENTED;
 }
 
 bool CGameLibRetro::GetEjectState()

--- a/src/client.h
+++ b/src/client.h
@@ -67,6 +67,9 @@ public:
   size_t SerializeSize() override;
   GAME_ERROR Serialize(uint8_t* data, size_t size) override;
   GAME_ERROR Deserialize(const uint8_t* data, size_t size) override;
+  size_t AchievementStateSize() override;
+  GAME_ERROR SerializeAchievements(uint8_t* data, size_t size) override;
+  GAME_ERROR DeserializeAchievements(const uint8_t* data, size_t size) override;
 
   // --- Cheat operations --------------------------------------------------------
 
@@ -75,25 +78,8 @@ public:
   GAME_ERROR SetCheat(unsigned int index, bool enabled, const std::string& code) override;
 
   // --- RCheevos ----------------------------------------------------------------
-  GAME_ERROR RCGenerateHashFromFile(std::string& hash,
-                                    unsigned int consoleID,
-                                    const std::string& filePath) override;
-  GAME_ERROR RCGetGameIDUrl(std::string& url, const std::string& hash) override;
-  GAME_ERROR RCGetPatchFileUrl(std::string& url,
-                               const std::string& username,
-                               const std::string& token,
-                               unsigned int gameID) override;
   GAME_ERROR SetRetroAchievementsCredentials(const std::string& username, const std::string& token) override;
-  GAME_ERROR RCPostRichPresenceUrl(std::string& url,
-                                   std::string& postData,
-                                   const std::string& username,
-                                   const std::string& token,
-                                   unsigned int gameID,
-                                   const std::string& richPresence) override;
-  GAME_ERROR RCEnableRichPresence(const std::string& script) override;
-  GAME_ERROR RCGetRichPresenceEvaluation(std::string& evaluation, unsigned int consoleID) override;
   GAME_ERROR ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression) override;
-  GAME_ERROR RCResetRuntime() override;
   GAME_ERROR GetCheevoUrlId(const std::function<void(const std::string& achievementUrl,
                                                      unsigned int cheevoId)>& callback) override;
 

--- a/src/utils/Base64.cpp
+++ b/src/utils/Base64.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "Base64.h"
+
+#include <stdint.h>
+
+namespace LIBRETRO
+{
+std::string Base64Encode(const std::string& data)
+{
+  static constexpr char alphabet[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  std::string encoded;
+  encoded.reserve(((data.size() + 2) / 3) * 4);
+
+  size_t i = 0;
+  while (i + 2 < data.size())
+  {
+    const uint32_t triple = (static_cast<uint8_t>(data[i]) << 16) |
+                            (static_cast<uint8_t>(data[i + 1]) << 8) |
+                            static_cast<uint8_t>(data[i + 2]);
+    encoded += alphabet[(triple >> 18) & 0x3F];
+    encoded += alphabet[(triple >> 12) & 0x3F];
+    encoded += alphabet[(triple >> 6) & 0x3F];
+    encoded += alphabet[triple & 0x3F];
+    i += 3;
+  }
+
+  if (i < data.size())
+  {
+    uint32_t triple = static_cast<uint8_t>(data[i]) << 16;
+    const bool haveTwo = (i + 1 < data.size());
+    if (haveTwo)
+      triple |= static_cast<uint8_t>(data[i + 1]) << 8;
+
+    encoded += alphabet[(triple >> 18) & 0x3F];
+    encoded += alphabet[(triple >> 12) & 0x3F];
+    encoded += haveTwo ? alphabet[(triple >> 6) & 0x3F] : '=';
+    encoded += '=';
+  }
+
+  return encoded;
+}
+} // namespace LIBRETRO

--- a/src/utils/Base64.h
+++ b/src/utils/Base64.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2020-2024 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace LIBRETRO
+{
+/*!
+ * \brief Encode data as base64
+ *
+ * Kodi's "postdata" protocol option is base64-decoded on receipt, so the body
+ * has to be encoded before it is handed over. The add-on SDK exposes no base64
+ * helper, hence this one.
+ */
+std::string Base64Encode(const std::string& data);
+} // namespace LIBRETRO


### PR DESCRIPTION
## Description

Moves RetroAchievements ownership from Kodi into game.libretro. Previously Kodi asked the add-on for URLs and then performed the HTTP and state management itself; now the add-on owns the whole achievement runtime and reports events to Kodi. This is the add-on-side counterpart to the [Kodi PR](https://github.com/xbmc/xbmc/pull/29074).

Flow:
`game.libretro (owns rc_client) → Game API 8.0.0 callbacks → Kodi (display only)`

**rc_client lifecycle (`src/cheevos/Cheevos.cpp`):**
- Created in `LoadGame()`, destroyed in `UnloadGame()`, ticked every `RunFrame()`
- Async login with the token Kodi supplies via `SetRetroAchievementsCredentials()`. Kodi may supply credentials either before or after the game loads, so the login starts from whichever arrives first.
- Memory read through `rc_libretro_memory_init`/`rc_libretro_memory_read`, which applies the console-specific address mapping, so multi-region layouts are handled without per-core special casing
- HTTP through the Kodi VFS rather than a bundled libcurl
- Hardcore explicitly disabled for now, since it requires savestates and rewind to be blocked while active

**Events forwarded to Kodi:**
`RCOnGameLoaded` (achievement set), `RCOnAchievementTriggered`, `RCOnGameCompleted`, `RCOnRichPresenceUpdated`, `RCOnLoginResult` (with the player's avatar URL)

**Dependency:** rcheevos v12.3.0 is already on `Piers` via #161. This adds the pieces that PR didn't carry — `rc_libretro.c` and its header for the console-specific memory mapping — and builds with `RC_STATIC` so the library's symbols aren't exported, and `RC_CLIENT_SUPPORTS_HASH` so `rc_client_begin_identify_and_load_game()` is compiled in rather than left unresolved.

> [!IMPORTANT]
> `azure-pipelines.yml` temporarily points CI at `sunlollyking/xbmc` branch `retroachievements-in-addon`, because CI cannot build without the Game API 8.0.0 headers from the companion PR. **This must be reverted to `xbmc/xbmc master` before merge.**

**Defects fixed, each of which independently prevented any achievement from ever unlocking:**

1. **Game identification never succeeded.** `rc_hash_generate_from_file()` was called with `RC_CONSOLE_UNKNOWN`, but its console switch has no case for it and the `default:` arm returns `"Unsupported console for file hash"`. Replaced with `rc_client_begin_identify_and_load_game()`, which runs the hash iterator and tries the methods that suit the file rather than requiring the console to be named up front — this is what makes coverage across cores work without a core-to-console table.

2. **Every POST was malformed, achievement awards included.** The body was appended to the URL as `"&postdata=<raw form data>"`. Kodi splits protocol options on `&` and base64-decodes the `postdata` value, so form data like `r=awardachievement&u=…&t=…` was shredded into stray options and whatever survived was decoded as base64. Requests now go through `CURLCreate()`/`CURLAddOption()`/`CURLOpen()` with the body base64 encoded as Kodi expects, `failonerror` disabled and the real status code reported so rc_client receives the RetroAchievements error body.

3. **Every achievement was disabled at session start.** rc_client validates achievement addresses as soon as the session begins, which is before the game-load callback runs. The memory map was built in that callback, so the read callback returned 0 and rc_client disabled all 142 of Sonic 2's achievements as out of range. The map is now built on first read, taking the console ID from `rc_client_get_game_info()`.

**Also:**
- System notices such as *"Warning: Unknown Emulator"* are filtered out. RetroAchievements publishes them as zero-point achievements marked unlocked, which would otherwise be listed and counted as if the player had earned them. Kodi's in-tree implementation filters these the same way.
- The User-Agent now identifies this add-on and its version and carries rcheevos' own clause, as `rc_client_get_user_agent_clause()` documents, instead of a hardcoded string. RetroAchievements identifies clients by User-Agent, so this is a prerequisite for the emulator being recognised rather than reported as unknown.

The old RC entry points are stubbed with `GAME_ERROR_NOT_IMPLEMENTED` and can be removed once no Kodi version in support calls them.

## Motivation and context

rcheevos was vendored directly into the Kodi source tree, which garbear identified as architecturally wrong — third-party libraries used by binary add-ons belong in the add-on. This PR gives game.libretro full ownership of the achievement runtime so Kodi only receives and displays events.

Depends on the Game API 8.0.0 structs and callbacks from [xbmc/xbmc#29074](https://github.com/xbmc/xbmc/pull/29074).

## How has this been tested?

Built on Ubuntu 26.04 x86_64 against Kodi's dev-kit headers at Game API 8.0.0, and exercised against a real RetroAchievements account.

**Verified end to end:** signed in, loaded Sonic the Hedgehog 2 (Mega Drive), and earned *Hold Your Breath* in play. The log shows identification, the achievement set loading with all achievements enabled, the trigger, the award submitted to RetroAchievements and the score updated. Also verified on Super Mario Bros. (NES) that a second console's memory mapping and achievement set load correctly.

- Verified the identification and HTTP defects against the rcheevos v12.3.0 sources and Kodi's `CurlFile`/`UrlOptions` option parsing, rather than by inference
- Verified the achievement-list lifetime assumption: `rc_client_create_achievement_list()` returns buckets of pointers into the client's own game data and `rc_client_destroy_achievement_list()` only frees the bucket block, so the strings stay valid after the list is destroyed
- Relinked with `-Wl,--no-undefined` to confirm no unresolved symbols, since a shared library hides them on Linux but Windows does not

Platforms tested: Ubuntu 26.04 (runtime), Windows Win32/Win64/ARM64/UWP (CI build)

## What is the effect on users?

Combined with the companion Kodi PR, achievements unlock while playing and are shown in the game OSD. Moving the runtime into the add-on is what allows this to work across libretro cores without Kodi carrying rcheevos or per-console hashing logic.

## Screenshots (if appropriate):

## Types of change

* [X] **Improvement** (non-breaking change which improves existing functionality)
* [X] **New feature** (non-breaking change which adds functionality)

## Checklist:

* [X] My code follows the [Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md) of this project
* [X] I have read the [Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md) document
* [ ] I have added tests to cover my change
* [X] All new and existing tests passed

