### PR TITLE
depends: Add libretro-common dependency to rcheevos

### DIFF
--- a/depends/common/rcheevos/deps.txt
+++ b/depends/common/rcheevos/deps.txt
@@ -1,0 +1,1 @@
+libretro-common


### PR DESCRIPTION
## Description

Add-ons use deps.txt to declare depednencies of dependencies. It looks like newer rcheevos requires libretro.h: 

```
In file included from /home/jenkins/jenkins-root/workspace/android-arm-docker@2/tools/depends/target/binary-addons/arm-linux-androideabi-24-release/build/rcheevos/src/rcheevos/src/rc_libretro.c:9:
/home/jenkins/jenkins-root/workspace/android-arm-docker@2/tools/depends/target/binary-addons/arm-linux-androideabi-24-release/build/rcheevos/src/rcheevos/src/rc_libretro.h:10:10: fatal error: 'libretro.h' file not found
   10 | #include <libretro.h>
      |          ^~~~~~~~~~~~
```

Building the single add-on worked by change, probably due to alphabetization, but building multiple add-ons in parallel can race and rcheevos will try to build before libretro-common.

## How has this been tested?

Build succeeds (see CI results).

Before, my test builds were broken without game.libretro. Now, test builds succeed and include game.libretro.