### PR TITLE
Take the settings a core declares through the core options API

### DIFF
--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -698,26 +698,35 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
   {
     unsigned int* typedData = static_cast<unsigned int*>(data);
+    if (typedData == nullptr)
+      return false;
 
-    // Not implemented
-    (void)typedData;
-    return false;
+    // Version 2. A core told 0 here falls back to SET_VARIABLES, which most do
+    // through libretro's own boilerplate -- but not all, and one that does not
+    // ends up with none of its settings registered at all.
+    *typedData = 2;
+    break;
   }
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS:
   {
-    const retro_core_option_definition* typedData = static_cast<const retro_core_option_definition*>(data);
+    const retro_core_option_definition* typedData =
+        static_cast<const retro_core_option_definition*>(data);
+    if (typedData == nullptr)
+      return false;
 
-    // Not implemented
-    (void)typedData;
-    return false;
+    m_settings.SetAllSettings(typedData);
+    break;
   }
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL:
   {
     const retro_core_options_intl* typedData = static_cast<const retro_core_options_intl*>(data);
+    if (typedData == nullptr || typedData->us == nullptr)
+      return false;
 
-    // Not implemented
-    (void)typedData;
-    return false;
+    // Only the American English set is taken. The translated one carries the
+    // same keys and values, differing in text this add-on does not display.
+    m_settings.SetAllSettings(typedData->us);
+    break;
   }
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY:
   {
@@ -834,11 +843,25 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   }
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
   {
-    const retro_core_options_v2_intl* typedData = static_cast<const retro_core_options_v2_intl*>(data);
+    const retro_core_options_v2* typedData = static_cast<const retro_core_options_v2*>(data);
+    if (typedData == nullptr || typedData->definitions == nullptr)
+      return false;
 
-    // Not implemented
-    (void)typedData;
-    return false;
+    // Categories are for grouping in a frontend's own settings UI, which this
+    // add-on does not build -- the settings are Kodi's
+    m_settings.SetAllSettings(typedData->definitions);
+    break;
+  }
+  case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL:
+  {
+    const retro_core_options_v2_intl* typedData =
+        static_cast<const retro_core_options_v2_intl*>(data);
+    if (typedData == nullptr || typedData->us == nullptr ||
+        typedData->us->definitions == nullptr)
+      return false;
+
+    m_settings.SetAllSettings(typedData->us->definitions);
+    break;
   }
   case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK:
   {

--- a/src/settings/LibretroSetting.cpp
+++ b/src/settings/LibretroSetting.cpp
@@ -8,6 +8,8 @@
 #include "LibretroSetting.h"
 #include "libretro-common/libretro.h"
 
+#include <algorithm>
+
 using namespace LIBRETRO;
 
 CLibretroSetting::CLibretroSetting(const retro_variable* libretroVariable) :
@@ -16,6 +18,33 @@ CLibretroSetting::CLibretroSetting(const retro_variable* libretroVariable) :
   Parse(libretroVariable->value);
 
   SetCurrentValue(DefaultValue());
+}
+
+CLibretroSetting::CLibretroSetting(const char* key,
+                                   const char* description,
+                                   std::vector<std::string> values,
+                                   const char* defaultValue)
+  : m_key(key != nullptr ? key : ""),
+    m_description(description != nullptr ? description : ""),
+    m_values(std::move(values))
+{
+  // Kept for the add-on's generated settings, which are written in the older
+  // pipe-delimited form whichever API the core used to declare them
+  for (const std::string& value : m_values)
+  {
+    if (!m_valuesStr.empty())
+      m_valuesStr += "|";
+    m_valuesStr += value;
+  }
+
+  // Unlike a retro_variable, this API names its default rather than leaving it
+  // implied by ordering. Fall back to the first value if the named one is not
+  // among them.
+  if (defaultValue != nullptr &&
+      std::find(m_values.begin(), m_values.end(), defaultValue) != m_values.end())
+    SetCurrentValue(defaultValue);
+  else
+    SetCurrentValue(DefaultValue());
 }
 
 const std::string& CLibretroSetting::DefaultValue() const

--- a/src/settings/LibretroSetting.h
+++ b/src/settings/LibretroSetting.h
@@ -19,6 +19,18 @@ namespace LIBRETRO
   public:
     CLibretroSetting(const retro_variable* libretroVariable);
 
+    /*!
+     * \brief Build a setting from the core options API
+     *
+     * The newer API hands the pieces over separately rather than in one
+     * semicolon-and-pipe string, and names its own default rather than relying
+     * on the first value being it.
+     */
+    CLibretroSetting(const char* key,
+                     const char* description,
+                     std::vector<std::string> values,
+                     const char* defaultValue);
+
     const std::string&              Key() const          { return m_key; }
     const std::string&              Description() const  { return m_description; }
     const std::vector<std::string>& Values() const       { return m_values; }

--- a/src/settings/LibretroSettings.cpp
+++ b/src/settings/LibretroSettings.cpp
@@ -102,6 +102,105 @@ void CLibretroSettings::SetAllSettings(const retro_variable* libretroVariables)
     GenerateSettings();
 }
 
+namespace
+{
+/*!
+ * \brief Collect the values a core options entry offers
+ *
+ * The array is terminated by an entry with a null value, and the label is for
+ * display only -- what a core reads back is the value.
+ */
+std::vector<std::string> GetOptionValues(const retro_core_option_value* values)
+{
+  std::vector<std::string> result;
+
+  for (const retro_core_option_value* value = values; value != nullptr && value->value != nullptr;
+       value++)
+    result.emplace_back(value->value);
+
+  return result;
+}
+} // namespace
+
+void CLibretroSettings::AddSetting(CLibretroSetting setting, bool& bValid)
+{
+  if (setting.Values().empty())
+  {
+    esyslog("Setting \"%s\": no values", setting.Key().c_str());
+    return;
+  }
+
+  std::string valueBuf;
+  if (kodi::addon::CheckSettingString(setting.Key(), valueBuf))
+  {
+    if (std::find(setting.Values().begin(), setting.Values().end(), valueBuf) !=
+        setting.Values().end())
+    {
+      dsyslog("Setting %s has value \"%s\" in Kodi", setting.Key().c_str(), valueBuf.c_str());
+      setting.SetCurrentValue(valueBuf);
+    }
+    else
+    {
+      esyslog("Setting %s: invalid value \"%s\" (values are: %s)", setting.Key().c_str(),
+              valueBuf.c_str(), setting.ValuesStr().c_str());
+      bValid = false;
+    }
+  }
+  else
+  {
+    esyslog("Setting %s not found by Kodi", setting.Key().c_str());
+    bValid = false;
+  }
+
+  m_settings.insert(std::make_pair(setting.Key(), std::move(setting)));
+}
+
+void CLibretroSettings::SetAllSettings(const retro_core_option_definition* definitions)
+{
+  bool bValid = true;
+
+  std::unique_lock<std::mutex> lock(m_mutex);
+
+  if (m_settings.empty())
+  {
+    for (const retro_core_option_definition* definition = definitions;
+         definition != nullptr && definition->key != nullptr; definition++)
+    {
+      AddSetting(CLibretroSetting(definition->key, definition->desc,
+                                  GetOptionValues(definition->values), definition->default_value),
+                 bValid);
+    }
+
+    m_bChanged = true;
+  }
+
+  if (!bValid)
+    GenerateSettings();
+}
+
+void CLibretroSettings::SetAllSettings(const retro_core_option_v2_definition* definitions)
+{
+  bool bValid = true;
+
+  std::unique_lock<std::mutex> lock(m_mutex);
+
+  if (m_settings.empty())
+  {
+    for (const retro_core_option_v2_definition* definition = definitions;
+         definition != nullptr && definition->key != nullptr; definition++)
+    {
+      AddSetting(CLibretroSetting(definition->key, definition->desc,
+                                  GetOptionValues(definition->values), definition->default_value),
+                 bValid);
+    }
+
+    m_bChanged = true;
+  }
+
+  if (!bValid)
+    GenerateSettings();
+}
+
 const char* CLibretroSettings::GetCurrentValue(const std::string& settingName)
 {
   std::unique_lock<std::mutex> lock(m_mutex);

--- a/src/settings/LibretroSettings.h
+++ b/src/settings/LibretroSettings.h
@@ -16,6 +16,8 @@
 
 class CGameLibRetro;
 struct retro_variable;
+struct retro_core_option_definition;
+struct retro_core_option_v2_definition;
 
 namespace LIBRETRO
 {
@@ -32,11 +34,27 @@ namespace LIBRETRO
 
     void SetAllSettings(const retro_variable* libretroVariables);
 
+    /*!
+     * \brief Take the settings a core declares through the core options API
+     *
+     * Same job as the retro_variable overload, for the two shapes the newer
+     * API uses. A core that speaks this API never calls SET_VARIABLES at all,
+     * so without these its settings are never registered and every value it
+     * asks for comes back empty.
+     */
+    void SetAllSettings(const retro_core_option_definition* definitions);
+    void SetAllSettings(const retro_core_option_v2_definition* definitions);
+
     const char* GetCurrentValue(const std::string& settingName);
 
     void SetCurrentValue(const std::string& name, const std::string& value);
 
   private:
+    /*!
+     * \brief Register one setting, checking it against what Kodi has
+     */
+    void AddSetting(CLibretroSetting setting, bool& bValid);
+
     /*!
      * \brief Generate settings and language files for Kodi
      */


### PR DESCRIPTION
Split out of #164 at @garbear's suggestion — this is independent of hardware rendering and applies to v22 on its own.

Cores declare their settings through `RETRO_ENVIRONMENT_SET_CORE_OPTIONS`, `_SET_CORE_OPTIONS_INTL` and `_SET_CORE_OPTIONS_V2`. game.libretro answered the older `SET_VARIABLES` call but not these, so any core that had moved to the newer API — which is most of them now — had all of its settings ignored. `GET_VARIABLE` then returned nothing and the core fell back to its compiled-in defaults, so changing a setting in Kodi did nothing at all.

This reads the newer forms into the same settings store the old one uses, so `GET_VARIABLE` answers from it as before.

### Testing

Exercised against Flycast, Dolphin, PPSSPP, melonDS, Kronos and mupen64plus-next on LibreELEC. Settings changed in Kodi now reach the core — verified per-core by changing a setting with a visible effect (internal resolution, renderer selection) and confirming the change took.
