### PR TITLE
Audio fixes: opening frames and async callback (Game API v7.0.0)

### DIFF
--- a/src/audio/AudioStream.cpp
+++ b/src/audio/AudioStream.cpp
@@ -7,6 +7,7 @@
 
 #include "AudioStream.h"
 #include "libretro/LibretroEnvironment.h"
+#include "log/Log.h"
 
 #include "client.h"
 
@@ -20,12 +21,14 @@ CAudioStream::CAudioStream() :
 
 void CAudioStream::Initialize(CGameLibRetro* addon)
 {
+  m_bLoggedOpenFailure = false;
   m_addon = addon;
 }
 
 void CAudioStream::Deinitialize()
 {
   m_stream.Close();
+  m_bLoggedOpenFailure = false;
   m_addon = nullptr;
 }
 
@@ -41,8 +44,22 @@ void CAudioStream::AddFrames_S16NE(const uint8_t* data, unsigned int size)
     properties.audio.format = GAME_PCM_FORMAT_S16NE;
     properties.audio.channel_map = channelMap;
 
-    if (m_stream.Open(properties))
+    // Opening the stream used to return, throwing away the frames that
+    // prompted it. Fall through and play them instead.
+    if (!m_stream.Open(properties))
+    {
+      // Said once rather than per frame: a core delivering audio into a stream
+      // that will not open is silent, and otherwise looks the same from the log
+      // as a core that never delivers any.
+      if (!m_bLoggedOpenFailure)
+      {
+        m_bLoggedOpenFailure = true;
+        esyslog("Failed to open the audio stream, this game will be silent");
+      }
       return;
+    }
+
+    m_bLoggedOpenFailure = false;
   }
 
   game_stream_packet packet{};

--- a/src/audio/AudioStream.h
+++ b/src/audio/AudioStream.h
@@ -34,5 +34,8 @@ namespace LIBRETRO
     CSingleFrameAudio     m_singleFrameAudio;
 
     kodi::addon::CInstanceGame::CStream m_stream;
+
+    //! \brief Set once a failed stream open has been reported
+    bool m_bLoggedOpenFailure{false};
   };
 }

--- a/src/libretro/ClientBridge.cpp
+++ b/src/libretro/ClientBridge.cpp
@@ -85,8 +85,11 @@ GAME_ERROR CClientBridge::AudioEnable(bool enabled)
 
 GAME_ERROR CClientBridge::AudioAvailable(void)
 {
+  // Most cores deliver audio as they run and never register this callback, so
+  // having none is the ordinary case rather than a failure. Saying otherwise
+  // reports an error once a frame for the whole session.
   if (!m_retro_audio_callback)
-    return GAME_ERROR_FAILED;
+    return GAME_ERROR_NOT_IMPLEMENTED;
 
   m_retro_audio_callback();
 


### PR DESCRIPTION
Split out of #164 at @garbear's suggestion — two independent audio fixes, neither of which needs hardware rendering.

Builds against **Game API v7.0.0**, i.e. Kodi master as it stands. The fast-forward work that was previously in this PR needs v7.1.0 and has moved to its own PR so these can merge in order.

### Don't throw away the audio frames that opened the stream

The first batch of frames a core delivers is the one that opens the stream, and it was being discarded rather than written once the stream existed. Cores that deliver audio in large infrequent batches lost an audible amount at the start of every game. Also logs once if the open fails, instead of silently dropping everything thereafter.

### A core with no async audio callback is not an error

`AudioAvailable()` returned `GAME_ERROR_FAILED` when the core hadn't registered the asynchronous audio callback. That's the normal case for most cores, and it made a routine condition look like a failure in the log. Returns `GAME_ERROR_NOT_IMPLEMENTED` instead, which is what "this core doesn't do that" is supposed to mean.

### Testing

Checked against Dolphin, PPSSPP, melonDS, Kronos and mupen64plus-next.
