### PR TITLE
Give each core its own system and save directories

### DIFF
--- a/src/libretro/LibretroResources.cpp
+++ b/src/libretro/LibretroResources.cpp
@@ -63,7 +63,17 @@ void CLibretroResources::Initialize(CGameLibRetro* addon)
 
 void CLibretroResources::Deinitialize()
 {
+  // All of this belongs to the add-on that is going away, and this object is
+  // reached through a process-wide singleton. Anything left behind is picked
+  // up by the next core loaded in the same session: the system directory is
+  // only set while empty, so the first core to load owned it for every core
+  // after it, and a Saturn core went looking for its BIOS in the N64 add-on's
+  // directory. The cached paths and resource directories carry the same way.
   m_addon = nullptr;
+  m_systemDirectory.clear();
+  m_saveDirectory.clear();
+  m_resourceDirectories.clear();
+  m_pathMap.clear();
 }
 
 const char* CLibretroResources::GetBasePath(const std::string& relPath)

--- a/src/libretro/LibretroResources.cpp
+++ b/src/libretro/LibretroResources.cpp
@@ -59,6 +59,12 @@ void CLibretroResources::Initialize(CGameLibRetro* addon)
     dsyslog("Creating save directory: %s", m_saveDirectory.c_str());
     kodi::vfs::CreateDirectory(m_saveDirectory);
   }
+
+  // A core finds its BIOS, fonts and other data files under this, and one
+  // pointed somewhere else fails in whatever way that core fails when its data
+  // is missing -- which is rarely a message saying so. Worth a line each time a
+  // core starts, given this used to be whichever core loaded first.
+  kodi::Log(ADDON_LOG_INFO, "System directory: %s", m_systemDirectory.c_str());
 }
 
 void CLibretroResources::Deinitialize()


### PR DESCRIPTION
Split out of #164 at @garbear's suggestion — independent of hardware rendering.

Every core was handed the same system directory. Cores that look for BIOS or firmware by a fixed filename then collide: Dreamcast wants `dc_boot.bin`, Saturn wants `saturn_bios.bin`, PSP wants its `assets` tree, and several cores write state into the system directory as well. One shared directory means one core's files are another core's surprises, and a user who wants two consoles working has to merge trees by hand.

This gives each core its own system directory and its own save directory, named after the add-on. The second commit logs which directory a core was given, because "the core can't find its BIOS" is otherwise very hard to diagnose from a log.

### Note for review

This changes where cores look, so a user with existing BIOS files in the shared directory will need to move them into the per-core one. Worth a mention in release notes. Happy to add a one-time migration that copies rather than moves, if you'd prefer that — I left it out to keep the change small and predictable.

### Testing

On LibreELEC with Flycast, Kronos, PPSSPP, melonDS, Dolphin and mupen64plus-next installed simultaneously: each core finds its own BIOS/firmware, and the log line makes it obvious where it looked.
