### PR TITLE
Guard the connected devices against being freed mid-frame

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -51,6 +51,8 @@ void CInputManager::SetControllerLayouts(const std::vector<kodi::addon::GameCont
 
 bool CInputManager::EnableKeyboard(const std::string &controllerId)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   if (!CControllerTopology::GetInstance().SetDevice(GAME_PORT_KEYBOARD, controllerId))
@@ -69,12 +71,16 @@ bool CInputManager::EnableKeyboard(const std::string &controllerId)
 
 void CInputManager::DisableKeyboard()
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   CControllerTopology::GetInstance().RemoveDevice(GAME_PORT_KEYBOARD);
   m_keyboard.reset();
 }
 
 bool CInputManager::EnableMouse(const std::string &controllerId)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   if (!CControllerTopology::GetInstance().SetDevice(GAME_PORT_MOUSE, controllerId))
@@ -93,12 +99,16 @@ bool CInputManager::EnableMouse(const std::string &controllerId)
 
 void CInputManager::DisableMouse()
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   CControllerTopology::GetInstance().RemoveDevice(GAME_PORT_MOUSE);
   m_mouse.reset();
 }
 
 libretro_device_t CInputManager::ConnectController(const std::string &address, const std::string &controllerId)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   unsigned int deviceType = RETRO_DEVICE_NONE; // Unmasked device type
 
   const int port = GetPortIndex(address);
@@ -152,6 +162,8 @@ libretro_device_t CInputManager::ConnectController(const std::string &address, c
 
 bool CInputManager::DisconnectController(const std::string &address)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   const int port = GetPortIndex(address);
@@ -199,6 +211,8 @@ bool CInputManager::IsMouse(const std::string& portAddress) const
 
 libretro_device_t CInputManager::GetDeviceType(const std::string &address) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   libretro_device_t deviceType = RETRO_DEVICE_NONE;
 
   int port = GetPortIndex(address);
@@ -222,6 +236,8 @@ libretro_device_t CInputManager::GetDeviceType(const std::string &address) const
 
 void CInputManager::ClosePorts(void)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   m_controllers.clear();
 }
 
@@ -232,6 +248,8 @@ void CInputManager::EnableAnalogSensors(unsigned int port, bool bEnabled)
 
 bool CInputManager::InputEvent(const game_input_event& event)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   std::string controllerId = event.controller_id != nullptr ? event.controller_id : "";
   std::string feature = event.feature_name != nullptr ? event.feature_name : "";
 
@@ -318,6 +336,8 @@ void CInputManager::LogInputDescriptors(const retro_input_descriptor* descriptor
 
 std::string CInputManager::ControllerID(unsigned int port) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   std::string controllerId;
 
   if (port < m_controllers.size())
@@ -332,6 +352,8 @@ std::string CInputManager::ControllerID(unsigned int port) const
 
 bool CInputManager::ButtonState(libretro_device_t device, unsigned int port, unsigned int buttonIndex) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bState = false;
 
   switch (device)
@@ -371,6 +393,8 @@ bool CInputManager::ButtonState(libretro_device_t device, unsigned int port, uns
 
 float CInputManager::AnalogButtonState(unsigned int port, unsigned int buttonIndex) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   float state = 0.0f;
 
   if (port < m_controllers.size())
@@ -385,6 +409,8 @@ float CInputManager::AnalogButtonState(unsigned int port, unsigned int buttonInd
 
 int CInputManager::DeltaX(libretro_device_t device, unsigned int port)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   int deltaX = 0;
 
   if (device == RETRO_DEVICE_MOUSE && m_mouse)
@@ -403,6 +429,8 @@ int CInputManager::DeltaX(libretro_device_t device, unsigned int port)
 
 int CInputManager::DeltaY(libretro_device_t device, unsigned int port)
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   int deltaY = 0;
 
   if (device == RETRO_DEVICE_MOUSE && m_mouse)
@@ -421,6 +449,8 @@ int CInputManager::DeltaY(libretro_device_t device, unsigned int port)
 
 bool CInputManager::AnalogStickState(unsigned int port, unsigned int analogStickIndex, float& x, float& y) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   if (port < m_controllers.size())
@@ -435,6 +465,8 @@ bool CInputManager::AnalogStickState(unsigned int port, unsigned int analogStick
 
 bool CInputManager::AbsolutePointerState(unsigned int port, unsigned int pointerIndex, float& x, float& y) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   if (port < m_controllers.size())
@@ -449,6 +481,8 @@ bool CInputManager::AbsolutePointerState(unsigned int port, unsigned int pointer
 
 bool CInputManager::AccelerometerState(unsigned int port, float& x, float& y, float& z) const
 {
+  std::unique_lock<std::recursive_mutex> lock(m_mutex);
+
   bool bSuccess = false;
 
   if (port < m_controllers.size())

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -157,6 +157,21 @@ namespace LIBRETRO
     void SetControllerInfo(const retro_controller_info* info);
 
   private:
+    /*!
+     * \brief Guards the connected devices
+     *
+     * A controller is connected and disconnected on the frontend's thread while
+     * the core reads the same slots from the thread it emulates on. Without
+     * this, disconnecting a controller mid-game frees a device the core is
+     * about to dereference -- Flycast took a genuine SIGSEGV that way, which it
+     * reports as a fastmem fault and turns into a DEBUGBREAK.
+     *
+     * Recursive because these calls are entered from several paths and this
+     * guards against a nested one deadlocking rather than asserting the
+     * absence of nesting.
+     */
+    mutable std::recursive_mutex m_mutex;
+
     DevicePtr m_keyboard;
     DevicePtr m_mouse;
     DeviceVector m_controllers;


### PR DESCRIPTION
Unplugging a controller during a game can crash the emulator.

`CInputManager` has no locking at all. Controllers are connected and disconnected on the frontend's thread, while the core reads the same slots from the thread it emulates on:

```cpp
if (m_controllers[port])
  bHandled = m_controllers[port]->Input().InputEvent(event);
```

Checked, then dereferenced. A `DisconnectController` landing between those two statements frees the device the second statement uses. There are around a dozen other reads of `m_controllers[port]` with the same exposure, plus `m_keyboard` and `m_mouse`.

### How it showed up

Disconnecting a Bluetooth pad mid-game. Flycast took a genuine SIGSEGV inside an emulated memory access, which its fastmem handler reported as a bad address before giving up:

```
libretro/common.cpp:359 E[COMMON]: SIGSEGV @ d0000 ... 0xd0000 -> was not in vram (dyna code 0)
libretro/libretro.cpp:3272 E[COMMON]: DEBUGBREAK!
```

and took the process down with SIGILL. That reads like an emulator bug and isn't one — the core was handed freed memory while polling input.

### The change

A mutex held across every path that touches the connected devices.

It's recursive deliberately. These functions are entered from several call paths and I would rather it not depend on my having proved that none of them nest — a deadlock here would be a worse failure than the one being fixed, and the cost is negligible on paths this short.

### Testing

Builds clean. I have not yet reproduced the crash on demand — it's a race, and the one occurrence was incidental. So this is reasoned from the code rather than demonstrated by a before/after, and I'd rather say so than imply I've proven it fixed. The unguarded check-then-dereference is plainly there either way.