### PR TITLE
Answer GET_FASTFORWARDING from the playback speed (Game API v7.1.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,9 @@ set(LIBRETRO_SOURCES src/client.cpp
                      src/settings/SettingsGenerator.cpp
                      src/utils/Timer.cpp
                      src/video/VideoGeometry.cpp
-                     src/video/VideoStream.cpp)
+                     src/video/VideoStream.cpp
+                     src/video/VideoTiming.cpp
+)
 
 set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/audio/AudioStream.h
@@ -96,7 +98,9 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/settings/SettingsTypes.h
                      src/utils/Timer.h
                      src/video/VideoGeometry.h
-                     src/video/VideoStream.h)
+                     src/video/VideoStream.h
+                     src/video/VideoTiming.h
+)
 
 build_addon(${PROJECT_NAME} LIBRETRO DEPLIBS)
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -255,6 +255,7 @@ GAME_ERROR CGameLibRetro::GetGameTiming(game_system_timing& timing_info)
 
   // Report info to CLibretroEnvironment
   CLibretroEnvironment::Get().UpdateVideoGeometry(retro_info.geometry);
+  CLibretroEnvironment::Get().VideoTiming().SetFrameRate(retro_info.timing.fps);
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -435,6 +435,10 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       //! @todo Report updated timing info to frontend
       const double fps = typedData->timing.fps;
       const double sampleRate = typedData->timing.sample_rate;
+
+      // Kept for GET_THROTTLE_STATE, which is asked how often the core is run
+      m_videoTiming.SetFrameRate(fps);
+
       break;
     }
   case RETRO_ENVIRONMENT_SET_PROC_ADDRESS_CALLBACK:
@@ -674,10 +678,11 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   case RETRO_ENVIRONMENT_GET_FASTFORWARDING:
   {
     bool* typedData = static_cast<bool*>(data);
-
-    // Not implemented
-    (void)typedData;
-    return false;
+    if (typedData != nullptr)
+    {
+      *typedData = CVideoTiming::IsFastForwarding(m_addon->GetPlaybackSpeed());
+    }
+    break;
   }
   case RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE:
   {
@@ -882,10 +887,11 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
   case RETRO_ENVIRONMENT_GET_THROTTLE_STATE:
   {
     retro_throttle_state* typedData = static_cast<retro_throttle_state*>(data);
-
-    // Not implemented
-    (void)typedData;
-    return false;
+    if (typedData != nullptr)
+    {
+      m_videoTiming.GetThrottleState(m_addon->GetPlaybackSpeed(), *typedData);
+    }
+    break;
   }
   case RETRO_ENVIRONMENT_GET_SAVESTATE_CONTEXT:
   {

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -12,6 +12,7 @@
 #include "MemoryMap.h"
 #include "settings/LibretroSettings.h"
 #include "video/VideoStream.h"
+#include "video/VideoTiming.h"
 
 #include <kodi/addon-instance/Game.h>
 
@@ -44,6 +45,7 @@ namespace LIBRETRO
     CClientBridge* GetClientBridge(void) { return m_clientBridge; }
 
     CVideoStream& Video(void) { return m_videoStream; }
+    CVideoTiming& VideoTiming(void) { return m_videoTiming; }
     CAudioStream& Audio(void) { return m_audioStream; }
 
     void CloseStreams();
@@ -87,6 +89,7 @@ namespace LIBRETRO
     CLibretroDLL* m_client;
     CClientBridge* m_clientBridge;
     CVideoStream m_videoStream;
+    CVideoTiming m_videoTiming;
     CAudioStream m_audioStream;
 
     GAME_PIXEL_FORMAT m_videoFormat;

--- a/src/video/VideoTiming.cpp
+++ b/src/video/VideoTiming.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2026 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "VideoTiming.h"
+
+#include "libretro-common/libretro.h"
+
+#include <cmath>
+
+using namespace LIBRETRO;
+
+bool CVideoTiming::IsFastForwarding(double playbackSpeed)
+{
+  return playbackSpeed > 1.0;
+}
+
+void CVideoTiming::GetThrottleState(double playbackSpeed,
+                                    retro_throttle_state& throttleState) const
+{
+  // Kodi's speed carries the player's meaning, so the mode falls out of it.
+  // Rewinding is reported for a negative speed even though the core is still
+  // run forwards, because Kodi rewinds by replaying saved states around a core
+  // that only knows how to go forwards.
+  if (playbackSpeed < 0.0)
+    throttleState.mode = RETRO_THROTTLE_REWINDING;
+  else if (playbackSpeed == 0.0)
+    throttleState.mode = RETRO_THROTTLE_FRAME_STEPPING;
+  else if (playbackSpeed > 1.0)
+    throttleState.mode = RETRO_THROTTLE_FAST_FORWARD;
+  else if (playbackSpeed < 1.0)
+    throttleState.mode = RETRO_THROTTLE_SLOW_MOTION;
+  else
+    throttleState.mode = RETRO_THROTTLE_VSYNC;
+
+  // How often the core is meant to run, which is its own rate scaled by how
+  // fast the user is going. Zero is the documented answer for "no known fixed
+  // rate", and is what a core gets before it has declared one.
+  throttleState.rate = static_cast<float>(m_frameRate * std::abs(playbackSpeed));
+}

--- a/src/video/VideoTiming.h
+++ b/src/video/VideoTiming.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2026 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+struct retro_throttle_state;
+
+namespace LIBRETRO
+{
+  class CVideoTiming
+  {
+  public:
+    // Timing interface
+    double GetFrameRate() const { return m_frameRate; }
+    void SetFrameRate(double frameRate) { m_frameRate = frameRate; }
+
+    // Libretro interface
+    static bool IsFastForwarding(double playbackSpeed);
+    void GetThrottleState(double playbackSpeed, retro_throttle_state& throttleState) const;
+
+  private:
+    double m_frameRate{0.0};
+  };
+} // namespace LIBRETRO


### PR DESCRIPTION
Split out of #167 at @garbear's request, so the audio fixes can merge against Game API v7.0.0 first.

**Depends on xbmc/xbmc#29002**, which adds `GetPlaybackSpeed()` to the Game API as **v7.1.0**. CI will stay red here until that merges — the failure is `'KodiGetPlaybackSpeed': is not a member of 'CGameLibRetro'`, because the add-on builds against Kodi master.

### Answer GET_FASTFORWARDING instead of declining it

Flycast does:

```c
if (settings.rend.ThreadedRendering)
  if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &fastforward))
    settings.aica.LimitFPS = !fastforward;
```

Declining the call left `LimitFPS` at 0, and Flycast's `WriteSample()` skips the batch callback entirely when it is zero — so every 512-frame buffer was silently discarded and Dreamcast games had no sound at all, on any platform. Declining a question is not the same as answering it.

### Answer it from the speed Kodi is running at

The first commit asserted that Kodi has no fast-forward for games and answered a flat "no". That was wrong: RetroPlayer has fast-forward and rewind. The second commit answers from the speed the player is actually running at, via the new `GetPlaybackSpeed()` callback. `GET_THROTTLE_STATE` is answered from the same value.

Rewind is Kodi replaying saved states rather than the client running backwards, so a negative speed means "the user is going backwards", not "run backwards" — the API documentation says so explicitly.

### Testing

On LibreELEC, Dreamcast games went from completely silent to producing audio.
