### PR TITLE
Game API v7.2.0: Allow updating game FPS/samplerate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 set(LIBRETRO_SOURCES src/client.cpp
                      src/audio/AudioStream.cpp
+                     src/audio/AudioTiming.cpp
                      src/audio/SingleFrameAudio.cpp
                      src/cheevos/Cheevos.cpp
                      src/cheevos/CheevosEnvironment.cpp
@@ -63,6 +64,7 @@ set(LIBRETRO_SOURCES src/client.cpp
 
 set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/audio/AudioStream.h
+                     src/audio/AudioTiming.h
                      src/audio/SingleFrameAudio.h
                      src/input/ButtonMapper.h
                      src/cheevos/Cheevos.h

--- a/src/audio/AudioStream.cpp
+++ b/src/audio/AudioStream.cpp
@@ -27,9 +27,15 @@ void CAudioStream::Initialize(CGameLibRetro* addon)
 
 void CAudioStream::Deinitialize()
 {
-  m_stream.Close();
+  CloseStream();
   m_bLoggedOpenFailure = false;
   m_addon = nullptr;
+}
+
+void CAudioStream::CloseStream()
+{
+  m_singleFrameAudio.Clear();
+  m_stream.Close();
 }
 
 void CAudioStream::AddFrames_S16NE(const uint8_t* data, unsigned int size)

--- a/src/audio/AudioStream.h
+++ b/src/audio/AudioStream.h
@@ -24,6 +24,7 @@ namespace LIBRETRO
 
     void Initialize(CGameLibRetro* addon);
     void Deinitialize();
+    void CloseStream();
 
     void AddFrame_S16NE(int16_t left, int16_t right) { m_singleFrameAudio.AddFrame(left, right); }
 

--- a/src/audio/AudioTiming.cpp
+++ b/src/audio/AudioTiming.cpp
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2026 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "AudioTiming.h"
+
+using namespace LIBRETRO;
+
+double CAudioTiming::GetSampleRate() const
+{
+  return m_sampleRate;
+}
+
+void CAudioTiming::SetSampleRate(double sampleRate)
+{
+  m_sampleRate = sampleRate;
+}

--- a/src/audio/AudioTiming.h
+++ b/src/audio/AudioTiming.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+namespace LIBRETRO
+{
+  class CAudioTiming
+  {
+  public:
+    double GetSampleRate() const;
+    void SetSampleRate(double sampleRate);
+
+  private:
+    double m_sampleRate{0.0};
+  };
+} // namespace LIBRETRO

--- a/src/audio/SingleFrameAudio.h
+++ b/src/audio/SingleFrameAudio.h
@@ -20,6 +20,7 @@ namespace LIBRETRO
     CSingleFrameAudio(CAudioStream* audioStream);
 
     void AddFrame(int16_t left, int16_t right);
+    void Clear() { m_data.clear(); }
 
   private:
     CAudioStream* const  m_audioStream;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -256,6 +256,7 @@ GAME_ERROR CGameLibRetro::GetGameTiming(game_system_timing& timing_info)
   // Report info to CLibretroEnvironment
   CLibretroEnvironment::Get().UpdateVideoGeometry(retro_info.geometry);
   CLibretroEnvironment::Get().VideoTiming().SetFrameRate(retro_info.timing.fps);
+  CLibretroEnvironment::Get().AudioTiming().SetSampleRate(retro_info.timing.sample_rate);
 
   return GAME_ERROR_NO_ERROR;
 }

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -432,12 +432,16 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
 
       UpdateVideoGeometry(typedData->geometry);
 
-      //! @todo Report updated timing info to frontend
       const double fps = typedData->timing.fps;
       const double sampleRate = typedData->timing.sample_rate;
 
-      // Kept for GET_THROTTLE_STATE, which is asked how often the core is run
       m_videoTiming.SetFrameRate(fps);
+      m_audioTiming.SetSampleRate(sampleRate);
+
+      game_system_timing timingInfo{};
+      timingInfo.fps = fps;
+      timingInfo.sample_rate = sampleRate;
+      m_addon->SetGameTiming(timingInfo);
 
       break;
     }

--- a/src/libretro/LibretroEnvironment.h
+++ b/src/libretro/LibretroEnvironment.h
@@ -9,6 +9,7 @@
 
 #include "LibretroResources.h"
 #include "audio/AudioStream.h"
+#include "audio/AudioTiming.h"
 #include "MemoryMap.h"
 #include "settings/LibretroSettings.h"
 #include "video/VideoStream.h"
@@ -47,6 +48,7 @@ namespace LIBRETRO
     CVideoStream& Video(void) { return m_videoStream; }
     CVideoTiming& VideoTiming(void) { return m_videoTiming; }
     CAudioStream& Audio(void) { return m_audioStream; }
+    CAudioTiming& AudioTiming(void) { return m_audioTiming; }
 
     void CloseStreams();
 
@@ -91,6 +93,7 @@ namespace LIBRETRO
     CVideoStream m_videoStream;
     CVideoTiming m_videoTiming;
     CAudioStream m_audioStream;
+    CAudioTiming m_audioTiming;
 
     GAME_PIXEL_FORMAT m_videoFormat;
     GAME_VIDEO_ROTATION m_videoRotation;


### PR DESCRIPTION
## Description

Completes a TODO exposed by https://github.com/xbmc/xbmc/pull/29002 - we can now tell a client what speed we're running at, but the client can't update Kodi with a new video framerate or audio samplerate.

No games were observed to be broken due to this missing function, but it should be included for completeness to de-risk timing problems in future testing.

Corresponding Kodi PR: https://github.com/xbmc/xbmc/pull/29020

## Motivation and context

This was left as a TODO in the game.libretro code in the `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` libretro callback: https://github.com/kodi-game/game.libretro/blob/5e6c7e892/src/libretro/LibretroEnvironment.cpp#L435

This PR completes that TODO by adding a callback for setting the timing info at runtime.

## How has this been tested?

Included in latest test builds.