### PR TITLE
Log when a feature resolves to nothing

### DIFF
--- a/src/input/LibretroDeviceInput.cpp
+++ b/src/input/LibretroDeviceInput.cpp
@@ -168,6 +168,25 @@ bool CLibretroDeviceInput::InputEvent(const game_input_event& event)
   const std::string strFeatureName = event.feature_name ? event.feature_name : "";
 
   int index = CButtonMapper::Get().GetLibretroIndex(strControllerId, strFeatureName);
+
+  // Say where a feature ended up, once, the first time it is actually pressed.
+  // Naming the libretro constant rather than the index, which on its own says
+  // nothing to a reader.
+  if (index >= 0 &&
+      m_reportedFeatures.insert(strControllerId + "/" + strFeatureName).second)
+  {
+    const libretro_device_t device =
+        CButtonMapper::Get().GetLibretroDevice(strControllerId, strFeatureName);
+    const std::string featureId = LibretroTranslator::GetFeatureId(device, index);
+
+    if (!featureId.empty())
+      dsyslog("Buttonmap: %s feature \"%s\" -> %s", strControllerId.c_str(),
+              strFeatureName.c_str(), featureId.c_str());
+    else
+      dsyslog("Buttonmap: %s feature \"%s\" -> libretro index %d", strControllerId.c_str(),
+              strFeatureName.c_str(), index);
+  }
+
   if (index >= 0)
   {
     switch (event.type)
@@ -291,6 +310,13 @@ bool CLibretroDeviceInput::InputEvent(const game_input_event& event)
 
     return true;
   }
+
+  // The press arrived and resolved to nothing, so the core will never see it.
+  // Reported once per feature: buttons repeat, and this is a property of the
+  // mapping rather than of the press.
+  if (m_unmappedFeatures.insert(strControllerId + "/" + strFeatureName).second)
+    esyslog("Buttonmap: %s feature \"%s\" does not resolve, the core will never see it",
+            strControllerId.c_str(), strFeatureName.c_str());
 
   return false;
 }

--- a/src/input/LibretroDeviceInput.h
+++ b/src/input/LibretroDeviceInput.h
@@ -10,6 +10,7 @@
 #include <kodi/addon-instance/Game.h>
 #include <mutex>
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,10 @@ namespace LIBRETRO
                       const std::string &feature,
                       unsigned int keyIndex,
                       const game_key_event &keyEvent);
+
+    //! \brief Features already reported, so each is logged once not per press
+    std::set<std::string> m_reportedFeatures;
+    std::set<std::string> m_unmappedFeatures;
 
     std::vector<game_digital_button_event> m_buttons;
     std::vector<game_analog_button_event>  m_analogButtons;

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -364,6 +364,26 @@ int LibretroTranslator::GetFeatureIndex(const std::string& strLibretroFeature)
   return -1;
 }
 
+std::string LibretroTranslator::GetFeatureId(libretro_device_t device, int featureIndex)
+{
+  const auto it = featureMap.find(device);
+  if (it == featureMap.end())
+    return "";
+
+  const auto& features = it->second;
+
+  const auto it2 = std::find_if(features.begin(), features.end(),
+    [featureIndex](const LibretroFeature& feature)
+    {
+      return featureIndex == feature.featureIndex;
+    });
+
+  if (it2 != features.end())
+    return it2->libretroId;
+
+  return "";
+}
+
 libretro_device_t LibretroTranslator::GetLibretroDevice(const std::string& strLibretroFeature)
 {
   for (const auto &it : featureMap)

--- a/src/libretro/LibretroTranslator.h
+++ b/src/libretro/LibretroTranslator.h
@@ -92,6 +92,20 @@ namespace LIBRETRO
     static int GetFeatureIndex(const std::string& strLibretroFeature);
 
     /*!
+     * \brief The libretro constant a feature index belongs to
+     *
+     * The inverse of GetFeatureIndex(), for logging: an index on its own says
+     * nothing to a reader, where RETRO_DEVICE_ID_JOYPAD_A does. Indices repeat
+     * between device types, so the type is needed to pick the right one.
+     *
+     * \param device The libretro device the index belongs to
+     * \param featureIndex The index to name
+     *
+     * \return The constant's name, or an empty string if the pair is unknown
+     */
+    static std::string GetFeatureId(libretro_device_t device, int featureIndex);
+
+    /*!
      * \brief Translate button/feature name (libretro buttonmap "mapto" field) to libretro index value.
      * \param strFeatureName The feature name to translate.
      * \return Translated button/feature id.


### PR DESCRIPTION
Two input fixes, split out of the hardware-rendering branch because neither has anything to do with hardware rendering. They are independent of each other too — the first is a bug, the second is diagnostics.

### Send a released trigger as zero, not fully pressed

An analog button was scaled as though it were an axis. A trigger runs 0 to 1, not -1 to 1, so the bipolar scaling turned a *released* trigger into `-1` rather than `0` — and a core that narrows the value into an unsigned byte reads that as fully pressed.

The effect is a trigger held down until the user pulls it. On Dreamcast that is the brake stuck on from the moment a game starts, which is how it was found — the car would not move.

Now scaled into libretro's `0..0x7fff` range directly, and clamped, so a value outside `0..1` cannot leave the range either.

### Say when a controller feature resolves to nothing

A feature whose button map entry does not resolve returns `-1` and is dropped. The user presses it, Kodi handles the event and hands it over, and it stops here with nothing said — indistinguishable, from the log, from a core that simply ignores that button. Every misdiagnosis of "the core does not support this" starts here.

Each controller feature is now reported once, the first time it is asked for, naming the libretro index it landed on or warning that it landed nowhere. Once per feature rather than per poll, so it costs a handful of lines at startup and nothing during play.

### Testing

Both verified against Dreamcast (flycast) with an 8BitDo pad, where the trigger bug was originally hit; the button map reporting was what identified two separate causes of dead input while working on the Dolphin and Saturn add-ons. Builds against current `xbmc/xbmc` master.
