### PR TITLE
Update rcheevos in preparation for Achievements work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(game.libretro)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(Kodi REQUIRED)
 find_package(LibretroCommon REQUIRED)
-find_package(TinyXML REQUIRED)
 find_package(Rcheevos REQUIRED)
+find_package(TinyXML REQUIRED)
+
+add_definitions(${RCHEEVOS_DEFINITIONS})
 
 include_directories(${KODI_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR}/..

--- a/cmake/FindRcheevos.cmake
+++ b/cmake/FindRcheevos.cmake
@@ -28,6 +28,11 @@ if(ENABLE_INTERNAL_RCHEEVOS)
   set(RCHEEVOS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/build/depends/include)
   set(RCHEEVOS_LIBRARY ${CMAKE_BINARY_DIR}/build/depends/lib/librcheevoslib.a)
 
+  set(rcheevos_dependencies)
+  if(TARGET libretro-common)
+    list(APPEND rcheevos_dependencies libretro-common)
+  endif()
+
   externalproject_add(rcheevos
                       URL ${RCHEEVOS_URL}
                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/download
@@ -36,6 +41,7 @@ if(ENABLE_INTERNAL_RCHEEVOS)
                       CMAKE_ARGS
                         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/build/depends
                         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                      DEPENDS ${rcheevos_dependencies}
                       BUILD_BYPRODUCTS ${RCHEEVOS_LIBRARY})
 else()
   find_path(RCHEEVOS_INCLUDE_DIR rcheevos.h
@@ -50,6 +56,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Rcheevos REQUIRED_VARS RCHEEVOS_LIBRARY RCHEEVOS_INCLUDE_DIR)
 
 if(RCHEEVOS_FOUND)
+  set(RCHEEVOS_DEFINITIONS -DRC_STATIC)
   set(RCHEEVOS_INCLUDE_DIRS ${RCHEEVOS_INCLUDE_DIR})
   set(RCHEEVOS_LIBRARIES ${RCHEEVOS_LIBRARY})
 endif()

--- a/depends/common/rcheevos/CMakeLists.txt
+++ b/depends/common/rcheevos/CMakeLists.txt
@@ -1,11 +1,31 @@
-project(rcheevos)
 cmake_minimum_required(VERSION 3.0...4.0)
+project(rcheevos)
+
+find_path(LIBRETRO_COMMON_INCLUDE_DIR
+  NAMES libretro.h
+  PATH_SUFFIXES libretro-common
+)
+
+if(NOT LIBRETRO_COMMON_INCLUDE_DIR)
+  message(FATAL_ERROR "libretro-common headers not found")
+endif()
+
+# Compiling statically
+add_definitions(-DRC_STATIC)
 
 # Disable Lua for now
 add_definitions(-DRC_DISABLE_LUA)
 
+# RC_CLIENT_SUPPORTS_HASH gates rc_client_begin_identify_and_load_game(), which
+# the add-on uses to identify a game without knowing its console up front. It
+# has to be defined for the library too, not just for our own translation
+# units, or the function is compiled out and the reference goes unresolved.
+add_definitions(-DRC_CLIENT_SUPPORTS_HASH)
+
 include_directories(
   include
+  src
+  ${LIBRETRO_COMMON_INCLUDE_DIR}
 )
 
 add_library(${PROJECT_NAME}lib
@@ -14,10 +34,11 @@ add_library(${PROJECT_NAME}lib
   src/rapi/rc_api_info.c
   src/rapi/rc_api_runtime.c
   src/rapi/rc_api_user.c
-  src/rc_client.c
   src/rc_client_external.c
   src/rc_client_raintegration.c
+  src/rc_client.c
   src/rc_compat.c
+  src/rc_libretro.c
   src/rc_util.c
   src/rc_version.c
   src/rcheevos/alloc.c
@@ -30,17 +51,17 @@ add_library(${PROJECT_NAME}lib
   src/rcheevos/operand.c
   src/rcheevos/rc_validate.c
   src/rcheevos/richpresence.c
-  src/rcheevos/runtime.c
   src/rcheevos/runtime_progress.c
+  src/rcheevos/runtime.c
   src/rcheevos/trigger.c
   src/rcheevos/value.c
   src/rhash/aes.c
   src/rhash/cdreader.c
-  src/rhash/hash.c
   src/rhash/hash_disc.c
   src/rhash/hash_encrypted.c
   src/rhash/hash_rom.c
   src/rhash/hash_zip.c
+  src/rhash/hash.c
   src/rhash/md5.c
 )
 
@@ -59,16 +80,17 @@ install(
     include/rc_api_request.h
     include/rc_api_runtime.h
     include/rc_api_user.h
-    include/rc_client.h
     include/rc_client_raintegration.h
+    include/rc_client.h
     include/rc_consoles.h
     include/rc_error.h
     include/rc_export.h
     include/rc_hash.h
-    include/rc_runtime.h
     include/rc_runtime_types.h
+    include/rc_runtime.h
     include/rc_util.h
     include/rcheevos.h
+    src/rc_libretro.h
   DESTINATION
     include/${PROJECT_NAME}
 )


### PR DESCRIPTION
## Description

Update rcheevos for https://github.com/kodi-game/game.libretro/pull/162.

## Motivation and context

The rcheevos stuff in https://github.com/kodi-game/game.libretro/pull/162 needs a little work. It doesn't build for LibreELEC, for example, due to `${CMAKE_INSTALL_PREFIX}/include/libretro-common` expanding to `/usr/include/libretro-common` and causing a compiler error when building LE.

## How has this been tested?

An earlier version included in test builds with working LibreELEC build: https://github.com/garbear/xbmc/releases/tag/retroplayer-22beta2-20260819

Also validating with CI.