### PR TITLE
Serve the joypad button bitmask a core asks for

### DIFF
--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -126,7 +126,23 @@ int16_t CFrontendBridge::InputState(unsigned int port, unsigned int device, unsi
   {
   case RETRO_DEVICE_JOYPAD:
   case RETRO_DEVICE_KEYBOARD:
-    inputState = CInputManager::Get().ButtonState(device, port, id) ? 1 : 0;
+    // A core may ask for every joypad button at once instead of one at a time.
+    // Without this the id falls through as an ordinary button index, runs off
+    // the end of the button array and reads as zero -- which a core that
+    // inverts the mask, as LRPS2 does for the active-low PS2 pad, reads as
+    // every button held. The pad is then dead with nothing logged anywhere.
+    if (device == RETRO_DEVICE_JOYPAD && id == RETRO_DEVICE_ID_JOYPAD_MASK)
+    {
+      for (unsigned int buttonId = 0; buttonId <= RETRO_DEVICE_ID_JOYPAD_R3; ++buttonId)
+      {
+        if (CInputManager::Get().ButtonState(device, port, buttonId))
+          inputState |= (1 << buttonId);
+      }
+    }
+    else
+    {
+      inputState = CInputManager::Get().ButtonState(device, port, id) ? 1 : 0;
+    }
     break;
 
   case RETRO_DEVICE_MOUSE:

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -692,8 +692,10 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
     // Parameter is ignored
     (void)data;
 
-    // Not implemented
-    return false;
+    // Served in CFrontendBridge::InputState, which assembles the mask from the
+    // individual button states. Saying yes only tells a core it may ask; a core
+    // that asks anyway without checking -- LRPS2 does -- is answered either way.
+    return true;
   }
   case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
   {


### PR DESCRIPTION
A core may read all sixteen joypad buttons in one call, passing
`RETRO_DEVICE_ID_JOYPAD_MASK` as the button id, rather than polling them one at
a time. That id was falling through as an ordinary button index, running off the
end of the sixteen-entry button array and reading as zero.

Zero is not a harmless answer. A core that inverts the mask — LRPS2 does,
because the PS2 pad is active low — turns it into `0xFFFF` and reads every
button as held, which the emulated console sees as a pad with nothing pressed.

The result is a completely dead controller with nothing logged on either side:
the input arrives, Kodi hands it over, the buttonmap resolves every feature, and
the core still sees nothing. It took a while to find precisely because every
layer reports success.

This assembles the mask from the individual button states, and answers
`GET_INPUT_BITMASKS` truthfully now that there is something behind it. LRPS2
never asks first, so it is served either way; cores that do ask get the faster
path.

Split out of #164, where it was found — it is an input fix and has nothing to do
with hardware rendering.

### Testing

Built against `Piers` and run on LibreELEC (GBM, Mesa) with LRPS2: the pad goes
from entirely dead to fully working, buttons and sticks. Cores that poll buttons
individually are unaffected — the new branch is only taken for the mask id.
