### PR TITLE
RetroAchievements  - On Screen Challenge/Progress Indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,22 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/video/VideoTiming.h
 )
 
+# The frontend gains the achievement indicator callbacks in Game API 8.1.0.
+# Against an older API they are not there, so build without forwarding them and
+# leave the frontend showing nothing. Detected rather than version-tested,
+# because the two land together and either may arrive first.
+include(CheckStructHasMember)
+check_struct_has_member("AddonToKodiFuncTable_Game"
+                        RCOnProgressIndicator
+                        "${KODI_INCLUDE_DIR}/c-api/addon-instance/game.h"
+                        HAVE_GAME_RC_INDICATORS
+                        LANGUAGE CXX)
+
 build_addon(${PROJECT_NAME} LIBRETRO DEPLIBS)
+
+if(HAVE_GAME_RC_INDICATORS)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GAME_RC_INDICATORS)
+endif()
 
 if(ENABLE_INTERNAL_LIBRETROCOMMON)
   add_dependencies(${PROJECT_NAME} libretro-common)

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -696,9 +696,60 @@ void CCheevos::RcheevosEventHandler(const rc_client_event_t* event, rc_client_t*
     case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
     case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
     {
-      // rc_client reports one achievement at a time, but the frontend shows a
-      // snapshot of every measured achievement, so publish the whole set
+      // Two things want this. The achievements dialog lists every measured
+      // achievement, so publish the whole set; the on-screen indicator shows
+      // the one the runtime picked out, so forward that as well.
       cheevos->PublishAchievementProgress();
+
+#if defined(HAVE_GAME_RC_INDICATORS)
+      const rc_client_achievement_t* achievement = event->achievement;
+      if (achievement != nullptr)
+      {
+        game_rc_progress_indicator indicator{};
+        indicator.id = achievement->id;
+        indicator.title = achievement->title;
+        indicator.badge_url = achievement->badge_url;
+        indicator.measured_progress = achievement->measured_progress;
+        indicator.measured_percent = achievement->measured_percent;
+
+        kodi::Log(ADDON_LOG_DEBUG,
+                  "CCheevos: forwarding progress indicator for achievement %u '%s' at %s",
+                  achievement->id, achievement->title != nullptr ? achievement->title : "",
+                  achievement->measured_progress != nullptr ? achievement->measured_progress : "");
+        cheevos->m_gameInstance->RCOnProgressIndicator(&indicator);
+      }
+#endif
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW:
+    {
+#if defined(HAVE_GAME_RC_INDICATORS)
+      const rc_client_achievement_t* achievement = event->achievement;
+      if (achievement != nullptr)
+      {
+        game_rc_challenge_indicator indicator{};
+        indicator.id = achievement->id;
+        indicator.title = achievement->title;
+        indicator.badge_url = achievement->badge_url;
+
+        cheevos->m_gameInstance->RCOnChallengeIndicator(&indicator);
+      }
+#endif
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE:
+    {
+#if defined(HAVE_GAME_RC_INDICATORS)
+      cheevos->m_gameInstance->RCOnChallengeIndicator(nullptr);
+#endif
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_HIDE:
+    {
+#if defined(HAVE_GAME_RC_INDICATORS)
+      // The runtime decides when the player has stopped working towards it
+      cheevos->m_gameInstance->RCOnProgressIndicator(nullptr);
+#endif
       break;
     }
     case RC_CLIENT_EVENT_SERVER_ERROR:


### PR DESCRIPTION
## Description

The challenge and progress indicator events already arrive from rc_client, and are used as a hint to republish the whole measured set. That set is what fills the bars in the achievements dialog, so it has to keep coming, but the choices the runtime made — which achievement is being attempted, which one the player is working towards, and when to stop showing either — were discarded with the event.

Forward them as well, through `RCOnChallengeIndicator` and `RCOnProgressIndicator`.

Pairs with garbear/xbmc#155, which is the frontend half and draws them.

## Motivation and context

The hide events send a null indicator, which is the only way the frontend can know the player has moved on — nothing in the measured set says so. The set keeps its own callback: the two answer different questions, every measured achievement so their progress can be listed, against the one or two that should be on screen right now.

## How has this been tested?

Built against the Game API 8.1.0 headers and run on GBM/Wayland GLES with Balloon Fight (fceumm) and Sonic the Hedgehog 2 (genplus), logged into RetroAchievements.

A traced run confirmed the events reaching the handler and being forwarded: rc_client raised `CHALLENGE_INDICATOR_SHOW/HIDE` and `PROGRESS_INDICATOR_SHOW/UPDATE/HIDE`, and the frontend received every one — "Ring Wrangler I" counting 6/226 through 12/226 on Sonic, "Trip Pop Pro" on Balloon Fight, each cleared on its hide.

## What is the effect on users?

A frontend that offers the callbacks shows the achievement being attempted and the one being worked towards while the game runs. Nothing changes for one that does not.

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Cosmetic

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires no change to the documentation
- [x] I have read the Contributing document
