### PR TITLE
RetroAchievements - Implement Encore Mode (Ability to reearn earned achievements)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,21 @@ set(LIBRETRO_HEADERS src/GameInfoLoader.h
                      src/video/VideoTiming.h
 )
 
+# The frontend gains the encore-mode call in Game API 8.1.0. Against an older
+# API it is not there, so build without it. Detected rather than version-tested,
+# because the two land together and either may arrive first.
+include(CheckStructHasMember)
+check_struct_has_member("KodiToAddonFuncTable_Game"
+                        RCSetEncoreModeEnabled
+                        "${KODI_INCLUDE_DIR}/c-api/addon-instance/game.h"
+                        HAVE_GAME_RC_ENCORE_MODE
+                        LANGUAGE CXX)
+
 build_addon(${PROJECT_NAME} LIBRETRO DEPLIBS)
+
+if(HAVE_GAME_RC_ENCORE_MODE)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GAME_RC_ENCORE_MODE)
+endif()
 
 if(ENABLE_INTERNAL_LIBRETROCOMMON)
   add_dependencies(${PROJECT_NAME} libretro-common)

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -122,6 +122,11 @@ void CCheevos::Initialize(kodi::addon::CInstanceGame* gameInstance,
       kodi::Log(ADDON_LOG_DEBUG, "rc_client: %s", message);
     });
 
+  // After logging is enabled, so the client reports the mode it starts in.
+  // Applied here as well as when it is set, because the frontend sends it once
+  // per game while the client is built per game.
+  rc_client_set_encore_mode_enabled(m_rcClient, m_encoreModeEnabled ? 1 : 0);
+
   // The frontend may not have supplied credentials yet, in which case
   // SetCredentials() starts the login when they arrive
   BeginLogin();
@@ -215,6 +220,18 @@ void CCheevos::Deinitialize()
   m_richPresenceActive = false;
   m_lastProgressSignature.clear();
   m_gameInstance = nullptr;
+}
+
+void CCheevos::SetEncoreModeEnabled(bool enabled)
+{
+  m_encoreModeEnabled = enabled;
+
+  kodi::Log(ADDON_LOG_INFO, "CCheevos: encore mode %s", enabled ? "enabled" : "disabled");
+
+  // Usually arrives before there is a client to tell: the frontend sends it as
+  // part of loading a game, and the client is created once that game is up
+  if (m_rcClient != nullptr)
+    rc_client_set_encore_mode_enabled(m_rcClient, enabled ? 1 : 0);
 }
 
 void CCheevos::SetCredentials(const std::string& username, const std::string& token)

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -47,6 +47,14 @@ public:
   /// @brief Store credentials from Kodi (called before LoadGame)
   void SetCredentials(const std::string& username, const std::string& token);
 
+  /*!
+   * \brief Play for achievements the user has already earned
+   *
+   * Kept as well as applied, because rc_client only reads it when a game is
+   * loaded and the frontend sends it before the load.
+   */
+  void SetEncoreModeEnabled(bool enabled);
+
   /// @brief Called every emulated frame from RunFrame()
   void DoFrame();
 
@@ -160,6 +168,7 @@ private:
   std::string m_userAgent;
   mutable std::mutex m_userAgentMutex;
   std::atomic<bool> m_loginStarted{false};
+  std::atomic<bool> m_encoreModeEnabled{false};
   bool m_loginRetryScheduled{false};
   unsigned int m_loginRetryDelaySeconds{0};
   std::chrono::steady_clock::time_point m_nextLoginAttempt;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -537,6 +537,14 @@ GAME_ERROR CGameLibRetro::SetRetroAchievementsCredentials(const std::string& use
   return GAME_ERROR_NO_ERROR;
 }
 
+#if defined(HAVE_GAME_RC_ENCORE_MODE)
+GAME_ERROR CGameLibRetro::RCSetEncoreModeEnabled(bool enabled)
+{
+  CCheevos::Get().SetEncoreModeEnabled(enabled);
+  return GAME_ERROR_NO_ERROR;
+}
+#endif
+
 GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression)
 {
   return GAME_ERROR_NOT_IMPLEMENTED;

--- a/src/client.h
+++ b/src/client.h
@@ -79,6 +79,9 @@ public:
 
   // --- RCheevos ----------------------------------------------------------------
   GAME_ERROR SetRetroAchievementsCredentials(const std::string& username, const std::string& token) override;
+#if defined(HAVE_GAME_RC_ENCORE_MODE)
+  GAME_ERROR RCSetEncoreModeEnabled(bool enabled) override;
+#endif
   GAME_ERROR ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression) override;
   GAME_ERROR GetCheevoUrlId(const std::function<void(const std::string& achievementUrl,
                                                      unsigned int cheevoId)>& callback) override;


### PR DESCRIPTION
A finished game is silent on a replay: every achievement is unlocked, none are
armed, and none fire. rc_client already has the answer -- encore mode makes the
unlock check always pass, so they arm again -- and this hands the frontend's
setting to it.

Pairs with xbmc/xbmc's `RCSetEncoreModeEnabled` (garbear/xbmc#156).

### Ordering

rc_client only reads the flag while loading a game, and the frontend sends it
before that load, so it is kept as well as applied: stored when it arrives, and
set on the client once there is one. It is applied after logging is enabled so
the client reports the mode it starts in.

### Building against a frontend without it

The call is detected at configure time with `check_struct_has_member` rather
than tested against an API version, because the frontend change and this one may
land in either order. Built against a frontend that lacks it, the override is
not compiled and the add-on behaves as before -- verified against stock Game API
8.0.0 headers, where the check reports `HAVE_GAME_RC_ENCORE_MODE - Failed` and
the build is clean.

### Tested

Balloon Fight (fceumm), account with 3 of its 25 achievements already earned.
Toggled live, reloading the same game each time:

| setting | rcheevos reports | achievements armed |
|---|---|---|
| encore on | `Encore mode enabled` | **26/26** |
| encore off | `Encore mode disabled` | **22/26** |
