### PR TITLE
Cheevos: encore mode, on-screen indicators and leaderboards

### DIFF
--- a/cmake/FindRcheevos.cmake
+++ b/cmake/FindRcheevos.cmake
@@ -11,6 +11,10 @@
 
 if(ENABLE_INTERNAL_RCHEEVOS)
   include(ExternalProject)
+  find_program(PATCH_EXECUTABLE NAMES patch)
+  if(NOT PATCH_EXECUTABLE)
+    message(FATAL_ERROR "patch is required to build internal rcheevos")
+  endif()
   file(STRINGS ${CMAKE_SOURCE_DIR}/depends/common/rcheevos/rcheevos.txt rcheevosurl REGEX "^rcheevos[\t ]*.+$")
   string(REGEX REPLACE "^rcheevos[\t ]*(.+)[\t ]*$" "\\1" url "${rcheevosurl}")
 
@@ -38,6 +42,8 @@ if(ENABLE_INTERNAL_RCHEEVOS)
                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/download
                       PREFIX ${CMAKE_BINARY_DIR}/build/rcheevos
                       PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/depends/common/rcheevos/CMakeLists.txt ${CMAKE_BINARY_DIR}/build/rcheevos/src/rcheevos/
+                      COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/depends/common/rcheevos/0001-preserve-encore-unlock-times.patch
+                      COMMAND ${PATCH_EXECUTABLE} -p1 -i ${CMAKE_SOURCE_DIR}/depends/common/rcheevos/0002-expose-zero-achievement-progress.patch
                       CMAKE_ARGS
                         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/build/depends
                         -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/depends/common/rcheevos/0001-preserve-encore-unlock-times.patch
+++ b/depends/common/rcheevos/0001-preserve-encore-unlock-times.patch
@@ -1,0 +1,98 @@
+From ec37a8567a50ef0a36efdd7e2a35d81bfc84c2cb Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 6 Sep 2026 00:29:29 -0700
+Subject: [PATCH] rc_client: Preserve unlock timestamps in Encore mode
+
+Encore activates achievements with RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE,
+which skips the normal assignment of the public unlock_time field. As a
+result, clients see previously earned achievements with a zero timestamp and
+cannot display their unlock dates.
+
+Populate the public timestamp independently of activation when Encore is
+enabled. Prefer the hardcore timestamp in hardcore mode when available,
+otherwise use the softcore timestamp. Keep achievements active for replay
+and leave never-earned achievements with an unset timestamp.
+
+Add regression coverage for softcore and hardcore Encore sessions, distinct
+unlock dates in each mode, and achievements without unlocks.
+---
+ src/rc_client.c       |  6 ++++++
+ test/test_rc_client.c | 38 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 44 insertions(+)
+
+diff --git a/src/rc_client.c b/src/rc_client.c
+index 08ea053..e0d5492 100644
+--- a/src/rc_client.c
++++ b/src/rc_client.c
+@@ -1433,6 +1433,12 @@ static uint32_t rc_client_subset_toggle_hardcore_achievements(rc_client_subset_i
+   uint32_t active_count = 0;
+ 
+   for (; achievement < stop; ++achievement) {
++    /* Encore keeps achievements active, but their previous unlock times remain available. */
++    if (client->state.encore_mode) {
++      achievement->public_.unlock_time = (client->state.hardcore && achievement->unlock_time_hardcore) ?
++          achievement->unlock_time_hardcore : achievement->unlock_time_softcore;
++    }
++
+     if ((achievement->public_.unlocked & active_bit) == 0) {
+       switch (achievement->public_.state) {
+         case RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED:
+diff --git a/test/test_rc_client.c b/test/test_rc_client.c
+index 707d02e..44fa6c1 100644
+--- a/test/test_rc_client.c
++++ b/test/test_rc_client.c
+@@ -10131,6 +10131,40 @@ static void test_set_hardcore_enable_encore_mode(void)
+   rc_client_destroy(g_client);
+ }
+ 
++static void test_encore_unlock_times(int hardcore, int earned)
++{
++  const rc_client_achievement_t* achievement;
++  const char* unlocks = "{\"Success\":true,\"Unlocks\":["
++      "{\"ID\":5501,\"When\":1234567800},{\"ID\":5502,\"When\":1234567899}"
++      "],\"HardcoreUnlocks\":[{\"ID\":5501,\"When\":1234567890}]}";
++
++  g_client = mock_client_logged_in();
++  rc_client_set_hardcore_enabled(g_client, hardcore);
++  rc_client_set_encore_mode_enabled(g_client, 1);
++  if (hardcore)
++    mock_client_load_game(patchdata_2ach_1lbd, earned ? unlocks : no_unlocks);
++  else
++    mock_client_load_game_softcore(patchdata_2ach_1lbd, earned ? unlocks : no_unlocks);
++
++  achievement = rc_client_get_achievement_info(g_client, 5501);
++  ASSERT_PTR_NOT_NULL(achievement);
++  if (achievement) {
++    ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
++    ASSERT_NUM_EQUALS(achievement->unlocked, earned ? RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH : RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE);
++    ASSERT_NUM_EQUALS(achievement->unlock_time, earned ? (hardcore ? 1234567890 : 1234567800) : 0);
++  }
++
++  achievement = rc_client_get_achievement_info(g_client, 5502);
++  ASSERT_PTR_NOT_NULL(achievement);
++  if (achievement) {
++    ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
++    ASSERT_NUM_EQUALS(achievement->unlocked, earned ? RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE : RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE);
++    ASSERT_NUM_EQUALS(achievement->unlock_time, earned ? 1234567899 : 0);
++  }
++
++  rc_client_destroy(g_client);
++}
++
+ static void test_set_encore_mode_enable(void)
+ {
+   const rc_client_achievement_t* achievement;
+@@ -10499,6 +10533,10 @@ void test_client(void) {
+   TEST(test_set_hardcore_enable);
+   TEST(test_set_hardcore_enable_no_game_loaded);
+   TEST(test_set_hardcore_enable_encore_mode);
++  TEST_PARAMS2(test_encore_unlock_times, 0, 0);
++  TEST_PARAMS2(test_encore_unlock_times, 0, 1);
++  TEST_PARAMS2(test_encore_unlock_times, 1, 0);
++  TEST_PARAMS2(test_encore_unlock_times, 1, 1);
+   TEST(test_set_encore_mode_enable);
+   TEST(test_set_encore_mode_disable);
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/depends/common/rcheevos/0002-expose-zero-achievement-progress.patch
+++ b/depends/common/rcheevos/0002-expose-zero-achievement-progress.patch
@@ -1,0 +1,172 @@
+From 07ae67b1c8fbdbb7b8c2861f3064dbc48defdb5f Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 6 Sep 2026 00:57:43 -0700
+Subject: [PATCH] rc_client: Expose zero progress for measured achievements
+
+Format known zero values using the measured target instead of leaving the
+progress string empty. Clients can display an unstarted counter such as 0/6,
+or 0% for percentage-based achievements. Keep unknown values and
+achievements without a measured target hidden.
+
+Cover zero-to-positive-to-zero transitions in normal and Encore mode, and
+retain the existing suppression of progress popups at zero.
+---
+ src/rc_client.c       |  6 +-----
+ test/test_rc_client.c | 50 ++++++++++++++++++++++++++++++++++---------
+ 2 files changed, 41 insertions(+), 15 deletions(-)
+
+diff --git a/src/rc_client.c b/src/rc_client.c
+index e0d5492..6970ae2 100644
+--- a/src/rc_client.c
++++ b/src/rc_client.c
+@@ -3920,10 +3920,6 @@ static void rc_client_update_achievement_display_information(rc_client_t* client
+         if (achievement->trigger->measured_value == RC_MEASURED_UNKNOWN) {
+           /* value hasn't been initialized yet, leave progress string empty */
+         }
+-        else if (achievement->trigger->measured_value == 0) {
+-          /* value is 0, leave progress string empty. update progress to 0.0 */
+-          achievement->public_.measured_percent = 0.0;
+-        }
+         else {
+           /* clamp measured value at target (can't get more than 100%) */
+           new_measured_value = (achievement->trigger->measured_value > achievement->trigger->measured_target) ?
+@@ -3938,7 +3934,7 @@ static void rc_client_update_achievement_display_information(rc_client_t* client
+             ptr[chars] = '/';
+             rc_format_value(ptr + chars + 1, buffer_size - chars - 1, (int32_t)achievement->trigger->measured_target, RC_FORMAT_UNSIGNED_VALUE);
+           }
+-          else if (achievement->public_.measured_percent >= 1.0) {
++          else if (achievement->public_.measured_percent >= 1.0 || new_measured_value == 0) {
+             snprintf(achievement->public_.measured_progress, sizeof(achievement->public_.measured_progress),
+                 "%lu%%", (unsigned long)achievement->public_.measured_percent);
+           }
+diff --git a/test/test_rc_client.c b/test/test_rc_client.c
+index 44fa6c1..757efa7 100644
+--- a/test/test_rc_client.c
++++ b/test/test_rc_client.c
+@@ -4464,6 +4464,34 @@ static void test_achievement_list_simple_with_unofficial_off(void)
+   rc_client_destroy(g_client);
+ }
+ 
++static void test_achievement_zero_progress(int encore)
++{
++  const uint32_t values[] = { 0, 2, 0, RC_MEASURED_UNKNOWN };
++  const char* expected[] = { "0/6", "2/6", "0/6", "" };
++  rc_client_achievement_list_t* list;
++  rc_client_achievement_info_t* achievement;
++  uint32_t i;
++
++  g_client = mock_client_logged_in();
++  rc_client_set_encore_mode_enabled(g_client, encore);
++  mock_client_load_game(patchdata_exhaustive, unlock_8);
++  achievement = (rc_client_achievement_info_t*)rc_client_get_achievement_info(g_client, 6);
++  ASSERT_PTR_NOT_NULL(achievement);
++  if (achievement) {
++    for (i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
++      achievement->trigger->measured_value = values[i];
++      list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
++          RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
++      ASSERT_PTR_NOT_NULL(list);
++      ASSERT_STR_EQUALS(achievement->public_.measured_progress, expected[i]);
++      ASSERT_FLOAT_EQUALS(achievement->public_.measured_percent, i == 1 ? 33.333333f : 0.0f);
++      ASSERT_STR_EQUALS(rc_client_get_achievement_info(g_client, 5)->measured_progress, "");
++      rc_client_destroy_achievement_list(list);
++    }
++  }
++  rc_client_destroy(g_client);
++}
++
+ static void test_achievement_list_buckets(void)
+ {
+   rc_client_achievement_list_t* list;
+@@ -4496,7 +4524,7 @@ static void test_achievement_list_buckets(void)
+     ASSERT_NUM_EQUALS(achievement->id, 5);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 6);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0/6");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 7);
+@@ -4504,11 +4532,11 @@ static void test_achievement_list_buckets(void)
+     ASSERT_NUM_EQUALS(achievement->id, 9);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 70);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0/100,000");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 71);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0%");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+ 
+     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
+@@ -4713,7 +4741,7 @@ static void test_achievement_list_buckets_progress_sort(void)
+     ASSERT_FLOAT_EQUALS(list->buckets[1].achievements[0]->measured_percent, 75.0f);
+     ASSERT_STR_EQUALS(list->buckets[1].achievements[0]->measured_progress, "75/100");
+     ASSERT_FLOAT_EQUALS(list->buckets[1].achievements[1]->measured_percent, 0.0f);
+-    ASSERT_STR_EQUALS(list->buckets[1].achievements[1]->measured_progress, "");
++    ASSERT_STR_EQUALS(list->buckets[1].achievements[1]->measured_progress, "0%");
+ 
+     rc_client_destroy_achievement_list(list);
+   }
+@@ -4770,7 +4798,7 @@ static void test_achievement_list_buckets_progress_sort_big_ids(void)
+     ASSERT_STR_EQUALS(list->buckets[1].label, "Locked");
+     ASSERT_NUM_EQUALS(list->buckets[1].num_achievements, 1);
+     ASSERT_FLOAT_EQUALS(list->buckets[1].achievements[0]->measured_percent, 0.0f);
+-    ASSERT_STR_EQUALS(list->buckets[1].achievements[0]->measured_progress, "");
++    ASSERT_STR_EQUALS(list->buckets[1].achievements[0]->measured_progress, "0%");
+ 
+     rc_client_destroy_achievement_list(list);
+   }
+@@ -5056,7 +5084,7 @@ static void test_achievement_list_subset_buckets(void)
+     ASSERT_NUM_EQUALS(achievement->id, 5);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 6);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0/6");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 7);
+@@ -5064,11 +5092,11 @@ static void test_achievement_list_subset_buckets(void)
+     ASSERT_NUM_EQUALS(achievement->id, 9);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 70);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0/100,000");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+     achievement = *iter++;
+     ASSERT_NUM_EQUALS(achievement->id, 71);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0%");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+ 
+     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
+@@ -7052,13 +7080,13 @@ static void test_do_frame_achievement_measured_progress_event(void)
+     rc_client_do_frame(g_client);
+     ASSERT_NUM_EQUALS(event_count, 0);
+ 
+-    /* don't trigger popup when value changes to 0 as the measured_progress string will be blank */
++    /* don't trigger popup when value changes to 0 */
+     memory[0x06] = 0; /* 0 */
+     rc_client_do_frame(g_client);
+     ASSERT_NUM_EQUALS(event_count, 0);
+ 
+     achievement = rc_client_get_achievement_info(g_client, 6);
+-    ASSERT_STR_EQUALS(achievement->measured_progress, "");
++    ASSERT_STR_EQUALS(achievement->measured_progress, "0/6");
+     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
+ 
+     /* both at 50%, only report first */
+@@ -10420,6 +10448,8 @@ void test_client(void) {
+   TEST(test_achievement_list_simple_with_unlocks_encore_mode);
+   TEST(test_achievement_list_simple_with_unofficial_and_unsupported);
+   TEST(test_achievement_list_simple_with_unofficial_off);
++  TEST_PARAMS1(test_achievement_zero_progress, 0);
++  TEST_PARAMS1(test_achievement_zero_progress, 1);
+   TEST(test_achievement_list_buckets);
+   TEST(test_achievement_list_buckets_progress_sort);
+   TEST(test_achievement_list_buckets_progress_sort_big_ids);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -122,6 +122,11 @@ void CCheevos::Initialize(kodi::addon::CInstanceGame* gameInstance,
       kodi::Log(ADDON_LOG_DEBUG, "rc_client: %s", message);
     });
 
+  // After logging is enabled, so the client reports the mode it starts in.
+  // Applied here as well as when it is set, because the frontend sends it once
+  // per game while the client is built per game.
+  rc_client_set_encore_mode_enabled(m_rcClient, m_encoreModeEnabled ? 1 : 0);
+
   // The frontend may not have supplied credentials yet, in which case
   // SetCredentials() starts the login when they arrive
   BeginLogin();
@@ -215,6 +220,18 @@ void CCheevos::Deinitialize()
   m_richPresenceActive = false;
   m_lastProgressSignature.clear();
   m_gameInstance = nullptr;
+}
+
+void CCheevos::SetEncoreModeEnabled(bool enabled)
+{
+  m_encoreModeEnabled = enabled;
+
+  kodi::Log(ADDON_LOG_INFO, "CCheevos: encore mode %s", enabled ? "enabled" : "disabled");
+
+  // Usually arrives before there is a client to tell: the frontend sends it as
+  // part of loading a game, and the client is created once that game is up
+  if (m_rcClient != nullptr)
+    rc_client_set_encore_mode_enabled(m_rcClient, enabled ? 1 : 0);
 }
 
 void CCheevos::SetCredentials(const std::string& username, const std::string& token)
@@ -696,9 +713,31 @@ void CCheevos::RcheevosEventHandler(const rc_client_event_t* event, rc_client_t*
     case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW:
     case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
     {
-      // rc_client reports one achievement at a time, but the frontend shows a
-      // snapshot of every measured achievement, so publish the whole set
+      // Two different things want this. The achievements dialog shows a
+      // snapshot of every measured achievement, so publish the whole set; the
+      // on-screen indicator shows the one the runtime picked out.
       cheevos->PublishAchievementProgress();
+
+      const rc_client_achievement_t* ach = event->achievement;
+      if (ach != nullptr)
+      {
+        game_rc_achievement_progress_indicator data{};
+        data.id = ach->id;
+        data.title = ach->title;
+        data.badge_url = ach->badge_url;
+        data.measured_progress = ach->measured_progress;
+        data.measured_percent = ach->measured_percent;
+
+        kodi::Log(ADDON_LOG_DEBUG,
+                  "CCheevos: progress indicator for achievement %u '%s' at %s (%.0f%%)", ach->id,
+                  ach->title != nullptr ? ach->title : "", ach->measured_progress,
+                  ach->measured_percent);
+
+        if (event->type == RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE)
+          cheevos->m_gameInstance->RCOnAchievementProgressUpdate(data);
+        else
+          cheevos->m_gameInstance->RCOnAchievementProgressIndicator(data, true);
+      }
       break;
     }
     case RC_CLIENT_EVENT_SERVER_ERROR:
@@ -722,6 +761,119 @@ void CCheevos::RcheevosEventHandler(const rc_client_event_t* event, rc_client_t*
     {
       kodi::Log(ADDON_LOG_INFO, "CCheevos: reconnected to RetroAchievements");
       cheevos->m_gameInstance->RCOnConnectionChanged(true);
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_HIDE:
+    {
+      // The achievement stopped reporting progress. Republish so the
+      // frontend's snapshot drops it rather than showing a stale bar.
+      cheevos->PublishAchievementProgress();
+
+      // rc_client may send no achievement with the hide, in which case an id
+      // of zero tells the frontend to clear whatever it is showing
+      game_rc_achievement_progress_indicator data{};
+      const rc_client_achievement_t* ach = event->achievement;
+      if (ach != nullptr)
+        data.id = ach->id;
+
+      cheevos->m_gameInstance->RCOnAchievementProgressIndicator(data, false);
+      break;
+    }
+    case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW:
+    case RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE:
+    {
+      const rc_client_achievement_t* ach = event->achievement;
+      if (ach != nullptr)
+      {
+        const bool show = (event->type == RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW);
+
+        game_rc_achievement_challenge data{};
+        data.id = ach->id;
+        data.title = ach->title;
+        data.badge_url = ach->badge_url;
+
+        kodi::Log(ADDON_LOG_DEBUG, "CCheevos: challenge indicator %s for achievement %u '%s'",
+                  show ? "show" : "hide", ach->id, ach->title != nullptr ? ach->title : "");
+
+        cheevos->m_gameInstance->RCOnChallengeIndicator(data, show);
+      }
+      break;
+    }
+    case RC_CLIENT_EVENT_SUBSET_COMPLETED:
+    {
+      const rc_client_subset_t* subset = event->subset;
+      const char* title = (subset != nullptr && subset->title != nullptr) ? subset->title : "";
+      cheevos->m_gameInstance->RCOnSubsetCompleted(title);
+      break;
+    }
+    case RC_CLIENT_EVENT_RESET:
+    {
+      // Raised when a mode change invalidates the session in progress
+      kodi::Log(ADDON_LOG_INFO, "CCheevos: runtime requested a reset");
+      cheevos->m_gameInstance->RCOnReset();
+      break;
+    }
+    case RC_CLIENT_EVENT_LEADERBOARD_STARTED:
+    case RC_CLIENT_EVENT_LEADERBOARD_FAILED:
+    case RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED:
+    {
+      const rc_client_leaderboard_t* lb = event->leaderboard;
+      if (lb != nullptr)
+      {
+        game_rc_leaderboard data{};
+        data.id = lb->id;
+        data.title = lb->title;
+        data.description = lb->description;
+        data.value = lb->tracker_value;
+
+        if (event->type == RC_CLIENT_EVENT_LEADERBOARD_STARTED)
+          cheevos->m_gameInstance->RCOnLeaderboardStarted(data);
+        else if (event->type == RC_CLIENT_EVENT_LEADERBOARD_FAILED)
+          cheevos->m_gameInstance->RCOnLeaderboardFailed(data);
+        else
+          cheevos->m_gameInstance->RCOnLeaderboardSubmitted(data);
+      }
+      break;
+    }
+    case RC_CLIENT_EVENT_LEADERBOARD_SCOREBOARD:
+    {
+      const rc_client_leaderboard_scoreboard_t* sb = event->leaderboard_scoreboard;
+      if (sb != nullptr)
+      {
+        // submitted_score and best_score are fixed-size buffers rather than
+        // pointers, so they are always safe to pass
+        game_rc_leaderboard_scoreboard data{};
+        data.id = sb->leaderboard_id;
+        data.submitted_score = sb->submitted_score;
+        data.best_score = sb->best_score;
+        data.new_rank = sb->new_rank;
+        data.num_entries = sb->num_entries;
+
+        kodi::Log(ADDON_LOG_INFO, "CCheevos: leaderboard %u placed %u of %u", sb->leaderboard_id,
+                  sb->new_rank, sb->num_entries);
+
+        cheevos->m_gameInstance->RCOnLeaderboardScoreboard(data);
+      }
+      break;
+    }
+    case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW:
+    case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE:
+    case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE:
+    {
+      const rc_client_leaderboard_tracker_t* tracker = event->leaderboard_tracker;
+      if (tracker != nullptr)
+      {
+        game_rc_leaderboard_tracker data{};
+        data.id = tracker->id;
+        data.display = tracker->display;
+
+        if (event->type == RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE)
+          cheevos->m_gameInstance->RCOnLeaderboardTracker(data, false);
+        else if (event->type == RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE)
+          cheevos->m_gameInstance->RCOnLeaderboardTrackerUpdate(data);
+        else
+          cheevos->m_gameInstance->RCOnLeaderboardTracker(data, true);
+      }
       break;
     }
     default:

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -47,6 +47,14 @@ public:
   /// @brief Store credentials from Kodi (called before LoadGame)
   void SetCredentials(const std::string& username, const std::string& token);
 
+  /*!
+   * \brief Play for achievements the user has already earned
+   *
+   * Kept as well as applied, because rc_client only reads it when a game is
+   * loaded and the frontend sends it before the load.
+   */
+  void SetEncoreModeEnabled(bool enabled);
+
   /// @brief Called every emulated frame from RunFrame()
   void DoFrame();
 
@@ -159,6 +167,7 @@ private:
   // Identifies this add-on to RetroAchievements, built once in Initialize()
   std::string m_userAgent;
   mutable std::mutex m_userAgentMutex;
+  std::atomic<bool> m_encoreModeEnabled{false};
   std::atomic<bool> m_loginStarted{false};
   bool m_loginRetryScheduled{false};
   unsigned int m_loginRetryDelaySeconds{0};

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -537,6 +537,12 @@ GAME_ERROR CGameLibRetro::SetRetroAchievementsCredentials(const std::string& use
   return GAME_ERROR_NO_ERROR;
 }
 
+GAME_ERROR CGameLibRetro::RCSetEncoreModeEnabled(bool enabled)
+{
+  CCheevos::Get().SetEncoreModeEnabled(enabled);
+  return GAME_ERROR_NO_ERROR;
+}
+
 GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression)
 {
   return GAME_ERROR_NOT_IMPLEMENTED;

--- a/src/client.h
+++ b/src/client.h
@@ -79,6 +79,7 @@ public:
 
   // --- RCheevos ----------------------------------------------------------------
   GAME_ERROR SetRetroAchievementsCredentials(const std::string& username, const std::string& token) override;
+  GAME_ERROR RCSetEncoreModeEnabled(bool enabled) override;
   GAME_ERROR ActivateAchievement(unsigned cheevo_id, const std::string& memAddrExpression) override;
   GAME_ERROR GetCheevoUrlId(const std::function<void(const std::string& achievementUrl,
                                                      unsigned int cheevoId)>& callback) override;


### PR DESCRIPTION
The add-on half of garbear/xbmc#162. Replaces #179 and #180, which are the same work split in two and without the leaderboards.

`rc_client` decides which achievement the player is attempting, how far along a counted one is, and everything a leaderboard does. All of it was being dropped: the indicators were used only as a hint to republish the whole measured set, so the runtime's actual choice was discarded. This forwards them.

Encore mode re-arms achievements already earned. It is kept as well as applied, because `rc_client` only reads it when a game loads and the frontend sends it before the load — so it usually arrives before there is a client to tell.

**Hardcore is not here.** `rc_client` is explicitly put in casual mode at init, and the add-on does not implement `RCSetHardcoreEnabled` — the frontend never calls it. It comes when RetroAchievements approve Kodi.

Conditionals dropped as you asked — no `check_struct_has_member`, no `#ifdef`s, `CMakeLists.txt` back to how it was. The two repos are assumed to be in lock step.

That does mean **CI cannot go green until Game API 8.1.0 is in `xbmc/xbmc` master.** `azure-pipelines.yml` builds against `git clone --branch master https://github.com/xbmc/xbmc.git`, so merging garbear/xbmc#162 into the fork is not enough on its own — the API has to reach upstream master.

The single failure is exactly that and nothing else:

```
src/client.h(82,14): error C3668: 'CGameLibRetro::RCSetEncoreModeEnabled':
method with override specifier 'override' did not override any base class methods
```

It builds clean against 8.1.0 (verified locally, both Linux and with the feature set complete).

This is the add-on the min bump in garbear/xbmc#162 requires to be rebuilt.

