### PR TITLE
Fix the performance microsecond clock

### DIFF
--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <chrono>
 #include <kodi/Filesystem.h>
 #include <kodi/General.h>
 #include <limits>
@@ -321,7 +322,9 @@ void CFrontendBridge::StopCamera(void)
 
 retro_time_t CFrontendBridge::PerfGetTimeUsec(void)
 {
-  return 0; // Not implemented
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
 }
 
 retro_perf_tick_t CFrontendBridge::PerfGetCounter(void)


### PR DESCRIPTION
## Description

Kodi exposes `RETRO_ENVIRONMENT_GET_PERF_INTERFACE`, but `CFrontendBridge::PerfGetTimeUsec()` always returns `0`.

This breaks cores that rely on the frontend performance clock. In DOSBox Pure, `DBP_GetTicks()` remained at zero, causing its menu debounce logic to discard selections indefinitely.

## Motivation and context

Fixes keyboard input in DOSBox-Pure.